### PR TITLE
Add Delonghi Dinamica Plus

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,5 +53,5 @@ Copy all files from this repository in custom_components/delonghi_primadonna to 
 ## Compartible devices
 
 * De'Longhi Primadonna Class ECAM 550.55
-* De'Longhi Dinamica Class ECAM 370.95
+* De'Longhi Dinamica Plus Class ECAM 370.95
 * Please add...

--- a/README.md
+++ b/README.md
@@ -53,4 +53,5 @@ Copy all files from this repository in custom_components/delonghi_primadonna to 
 ## Compartible devices
 
 * De'Longhi Primadonna Class ECAM 550.55
+* De'Longhi Dinamica Class ECAM 370.95
 * Please add...

--- a/custom_components/delonghi_primadonna/button.py
+++ b/custom_components/delonghi_primadonna/button.py
@@ -29,7 +29,7 @@ async def async_setup_entry(
 
 class DelongiPrimadonnaPowerButton(DelonghiDeviceEntity, ButtonEntity):
 
-    _attr_name = 'Turn on'
+    _attr_name = 'Turn on ECAM'
 
     async def async_press(self):
         self.hass.async_create_task(self.device.power_on())

--- a/custom_components/delonghi_primadonna/translations/fr.json
+++ b/custom_components/delonghi_primadonna/translations/fr.json
@@ -1,0 +1,20 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Le dispositif est déjà configuré"
+        },
+        "error": {
+            "cannot_connect": "chec de la connexion",
+            "invalid_auth": "Authentification invalide",
+            "unknown": "Erreur inattendue"
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "mac": "MAC",
+                    "name": "Nom"
+                }
+            }
+        }
+    }
+}

--- a/custom_components/delonghi_primadonna/translations/fr.json
+++ b/custom_components/delonghi_primadonna/translations/fr.json
@@ -4,7 +4,7 @@
             "already_configured": "Le dispositif est déjà configuré"
         },
         "error": {
-            "cannot_connect": "chec de la connexion",
+            "cannot_connect": "Echec de la connexion",
             "invalid_auth": "Authentification invalide",
             "unknown": "Erreur inattendue"
         },


### PR DESCRIPTION
Hello, 

Here is my PR to add the Delonghi Dinamica Plus coffee machine. 

I also added a french translation, and renamed the "button.turn_on" to "button_turn_on_ecam" because I think it is too generic and can interfere with other buttons already configured by other integration. 

In a more general way, I propose to rename the integration. Indeed, it does not only concern the Primadonna, but also the Dinamica Plus for example. What do you think about it?

Thanks for all the work done, it's great. 

Kind regards