### PR TITLE
Update manifests to clarify device support

### DIFF
--- a/custom_components/delonghi_primadonna/manifest.json
+++ b/custom_components/delonghi_primadonna/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "delonghi_primadonna",
-  "name": "Delonghi Primadonna",
+  "name": "DeLonghi BLE",
   "bluetooth": [
     {
       "service_data_uuid": "00035b03-58e6-07dd-021a-08123a000301"

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-  "name": "Delonghi Primadonna",
+  "name": "DeLonghi BLE.",
   "render_readme": true,
   "homeassistant": "2023.1.1",
   "hide_default_branch": true,


### PR DESCRIPTION
This integration currently only supports BLE but does support more devices than just the Primadonna, so have renamed it to DeLonghi BLE.