### PR TITLE
Update manifest to clarify device support

### DIFF
--- a/custom_components/delonghi_primadonna/manifest.json
+++ b/custom_components/delonghi_primadonna/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "delonghi_primadonna",
-  "name": "Delonghi Primadonna",
+  "name": "DeLonghi BLE",
   "bluetooth": [
     {
       "service_data_uuid": "00035b03-58e6-07dd-021a-08123a000301"


### PR DESCRIPTION
This integration currently only supports BLE but does support more devices than just the Primadonna, so have renamed it to DeLonghi BLE.