### PR TITLE
Update HACS to clarify device support

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-  "name": "Delonghi Primadonna",
+  "name": "DeLonghi BLE.",
   "render_readme": true,
   "homeassistant": "2023.1.1",
   "hide_default_branch": true,


### PR DESCRIPTION
This integration currently only supports BLE but does support more devices than just the Primadonna, so have renamed it to DeLonghi BLE.