### PR TITLE
Fix message mutation

### DIFF
--- a/custom_components/delonghi_primadonna/device.py
+++ b/custom_components/delonghi_primadonna/device.py
@@ -258,7 +258,7 @@ class DelongiPrimadonna:
         base_command[3] = '1' if self.switches.energy_save else '0'
         base_command[4] = '1' if self.switches.cup_light else '0'
         base_command[5] = '1' if self.switches.sounds else '0'
-        hex_command = BYTES_SWITCH_COMMAND
+        hex_command = copy.deepcopy(BYTES_SWITCH_COMMAND)
         hex_command[9] = int(''.join(base_command), 2)
         return hex_command
 
@@ -420,16 +420,17 @@ class DelongiPrimadonna:
         await self.send_command(message)
 
     async def send_command(self, message, retries=3):
+        message_to_send = copy.deepcopy(message)
         for attempt in range(retries):
             try:
                 await self._connect()
-                sign_request(message)
+                sign_request(message_to_send)
                 _LOGGER.info(
                     'Send command: %s',
-                    hexlify(bytearray(message), " ")
+                    hexlify(bytearray(message_to_send), " ")
                 )
                 await self._client.write_gatt_char(
-                    CONTROLL_CHARACTERISTIC, bytearray(message)
+                    CONTROLL_CHARACTERISTIC, bytearray(message_to_send)
                 )
                 return
             except BleakError as error:

--- a/custom_components/delonghi_primadonna/device.py
+++ b/custom_components/delonghi_primadonna/device.py
@@ -258,7 +258,7 @@ class DelongiPrimadonna:
         base_command[3] = '1' if self.switches.energy_save else '0'
         base_command[4] = '1' if self.switches.cup_light else '0'
         base_command[5] = '1' if self.switches.sounds else '0'
-        hex_command = copy.deepcopy(BYTES_SWITCH_COMMAND)
+        hex_command = BYTES_SWITCH_COMMAND.copy()
         hex_command[9] = int(''.join(base_command), 2)
         return hex_command
 


### PR DESCRIPTION
## Summary
- fix message copy before CRC signing
- make switch command copy constant command list

## Testing
- `isort --diff --check-only custom_components`
- `flake8 custom_components`

------
https://chatgpt.com/codex/tasks/task_e_6840c4795848832092bfdabfe6bef24e

## Summary by Sourcery

Prevent unintended mutation of command data by cloning message buffers before bit manipulations and CRC signing

Bug Fixes:
- Deep copy BYTES_SWITCH_COMMAND in _make_switch_command to avoid altering the constant command list
- Copy outgoing message in send_command before CRC signing and transmission to preserve the original message