### PR TITLE
Fix README heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Copy all files from this repository in custom_components/delonghi_primadonna to 
 ![Charts](./images/image.png)
 
 
-## Compartible devices
+## Compatible devices
 
 * De'Longhi ECAM 550.55
 * De'Longhi Dinamica Plus Class ECAM 370.95


### PR DESCRIPTION
## Summary
- fix typo in README heading

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840c5fd5e6883208898d16d7dc4727e