### PR TITLE
Fix BLE session cleanup

### DIFF
--- a/custom_components/delonghi_primadonna/device.py
+++ b/custom_components/delonghi_primadonna/device.py
@@ -225,7 +225,7 @@ class DelongiPrimadonna:
                     asyncio.TimeoutError,
                     Exception,
                 ) as error:  # noqa: BLE001
-                    _LOGGER.warning("Forced disconnect: %s", error)
+                    _LOGGER.warning("Forced disconnect [%s]: %s", type(error).__name__, error)
                 finally:
                     self._client = None
                     self.connected = False


### PR DESCRIPTION
## Summary
- ensure disconnect handles stuck connections by timeout
- add retries for connect with timeouts and cleanup

## Testing
- `isort custom_components/delonghi_primadonna/device.py`
- `flake8 custom_components/delonghi_primadonna`

------
https://chatgpt.com/codex/tasks/task_e_684165006f5083209ea881a0e27d9d84

## Summary by Sourcery

Improve BLE session reliability by adding timeouts, retry logic, and ensuring proper client cleanup during connect and disconnect operations.

Bug Fixes:
- Ensure stuck BLE sessions are forcibly disconnected and client state is consistently reset on errors.
- Clear client reference and connection flag when no active connection exists or disconnect fails.

Enhancements:
- Add timeouts around BLE disconnect, connect, service discovery, and notification setup to prevent hangs.
- Introduce retry logic for BLE connection attempts with cleanup and backoff between tries.