### PR TITLE
Add romanian, hungarian, chinese, japanese and korean translations

### DIFF
--- a/custom_components/delonghi_primadonna/translations/de.json
+++ b/custom_components/delonghi_primadonna/translations/de.json
@@ -1,20 +1,89 @@
 {
-    "config": {
-        "abort": {
-            "already_configured": "Gerät ist bereits konfiguriert"
-        },
-        "error": {
-            "cannot_connect": "Verbindung fehlgeschlagen",
-            "invalid_auth": "Ungültige Authentifizierung",
-            "unknown": "Unerwarteter Fehler"
-        },
-        "step": {
-            "user": {
-                "data": {
-                    "mac": "MAC",
-                    "name": "Name"
-                }
-            }
+  "config": {
+    "abort": {
+      "already_configured": "Gerät ist bereits konfiguriert"
+    },
+    "error": {
+      "cannot_connect": "Verbindung fehlgeschlagen",
+      "invalid_auth": "Ungültige Authentifizierung",
+      "unknown": "Unerwarteter Fehler"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "mac": "MAC",
+          "name": "Name"
         }
+      }
     }
+  },
+  "entity": {
+    "select": {
+      "profile": {
+        "name": "Profil"
+      },
+      "make_beverage": {
+        "name": "Getränk"
+      },
+      "energy_save_mode": {
+        "name": "Danach ausschalten"
+      },
+      "water_hardness": {
+        "name": "Wasserhärte"
+      },
+      "water_temperature": {
+        "name": "Wassertemperatur"
+      }
+    },
+    "button": {
+      "power_on": {
+        "name": "Sich einschalten"
+      }
+    },
+    "switch": {
+      "cup_light": {
+        "name": "Tasse Licht"
+      },
+      "debug_notification": {
+        "name": "Debugg -Benachrichtigung"
+      },
+      "energy_save_mode": {
+        "name": "Energiesparmodus"
+      },
+      "sounds": {
+        "name": "Geräusche"
+      }
+    }
+  },
+  "services": {
+    "make_beverage": {
+      "name": "Getränk machen",
+      "description": "Bereiten Sie ein Getränk aus der folgenden Liste vor",
+      "fields": {
+        "beverage": {
+          "name": "Getränk",
+          "description": "Getränk zur Vorbereitung"
+        },
+        "entity_id": {
+          "name": "Entity ID",
+          "description": "Entitäts -ID der Kaffeemaschine"
+        }
+      }
+    }
+  },
+  "selector": {
+    "beverage": {
+      "options": {
+        "none": "Keiner",
+        "steam": "Dampf",
+        "long": "Lang",
+        "coffee": "Kaffee",
+        "dopio": "DOPPELT",
+        "hot_water": "Heißes Wasser",
+        "espresso": "Espresso",
+        "americano": "Americano",
+        "espresso2": "Espresso 2"
+      }
+    }
+  }
 }

--- a/custom_components/delonghi_primadonna/translations/fr.json
+++ b/custom_components/delonghi_primadonna/translations/fr.json
@@ -1,20 +1,89 @@
 {
-    "config": {
-        "abort": {
-            "already_configured": "Le dispositif est déjà configuré"
-        },
-        "error": {
-            "cannot_connect": "Echec de la connexion",
-            "invalid_auth": "Authentification invalide",
-            "unknown": "Erreur inattendue"
-        },
-        "step": {
-            "user": {
-                "data": {
-                    "mac": "MAC",
-                    "name": "Nom"
-                }
-            }
+  "config": {
+    "abort": {
+      "already_configured": "Le dispositif est déjà configuré"
+    },
+    "error": {
+      "cannot_connect": "Echec de la connexion",
+      "invalid_auth": "Authentification invalide",
+      "unknown": "Erreur inattendue"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "mac": "MAC",
+          "name": "Nom"
         }
+      }
     }
+  },
+  "entity": {
+    "select": {
+      "profile": {
+        "name": "Profil"
+      },
+      "make_beverage": {
+        "name": "Boisson"
+      },
+      "energy_save_mode": {
+        "name": "Éteindre après"
+      },
+      "water_hardness": {
+        "name": "Dureté de l'eau"
+      },
+      "water_temperature": {
+        "name": "Température de l'eau"
+      }
+    },
+    "button": {
+      "power_on": {
+        "name": "Allumer"
+      }
+    },
+    "switch": {
+      "cup_light": {
+        "name": "Mettre un feu à la lumière"
+      },
+      "debug_notification": {
+        "name": "Notification de débogage"
+      },
+      "energy_save_mode": {
+        "name": "Mode d'économie d'énergie"
+      },
+      "sounds": {
+        "name": "Sons"
+      }
+    }
+  },
+  "services": {
+    "make_beverage": {
+      "name": "Faire des boissons",
+      "description": "Préparez une boisson à partir de la liste ci-dessous",
+      "fields": {
+        "beverage": {
+          "name": "Boisson",
+          "description": "Boisson à préparer"
+        },
+        "entity_id": {
+          "name": "ID de l'entité",
+          "description": "ID de l'entité de la machine à café"
+        }
+      }
+    }
+  },
+  "selector": {
+    "beverage": {
+      "options": {
+        "none": "Aucun",
+        "steam": "Vapeur",
+        "long": "Long",
+        "coffee": "Café",
+        "dopio": "DOUBLE",
+        "hot_water": "Eau chaude",
+        "espresso": "Espresso",
+        "americano": "Américain",
+        "espresso2": "Expresso 2"
+      }
+    }
+  }
 }

--- a/custom_components/delonghi_primadonna/translations/hu.json
+++ b/custom_components/delonghi_primadonna/translations/hu.json
@@ -1,0 +1,89 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "Az eszköz már konfigurálva van"
+    },
+    "error": {
+      "cannot_connect": "Nem sikerült csatlakozni",
+      "invalid_auth": "Érvénytelen hitelesítés",
+      "unknown": "Váratlan hiba"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "mac": "MAC",
+          "name": "Név"
+        }
+      }
+    }
+  },
+  "entity": {
+    "select": {
+      "profile": {
+        "name": "Profil"
+      },
+      "make_beverage": {
+        "name": "Ital"
+      },
+      "energy_save_mode": {
+        "name": "Kapcsolja ki utána"
+      },
+      "water_hardness": {
+        "name": "Vízkeménység"
+      },
+      "water_temperature": {
+        "name": "Vízhőmérséklet"
+      }
+    },
+    "button": {
+      "power_on": {
+        "name": "Bekapcsol"
+      }
+    },
+    "switch": {
+      "cup_light": {
+        "name": "Csésze lámpa"
+      },
+      "debug_notification": {
+        "name": "Hibakeresési értesítés"
+      },
+      "energy_save_mode": {
+        "name": "Energiamegtakarítás mód"
+      },
+      "sounds": {
+        "name": "Hangok"
+      }
+    }
+  },
+  "services": {
+    "make_beverage": {
+      "name": "Italt készít",
+      "description": "Készítsen italt az alábbi listából",
+      "fields": {
+        "beverage": {
+          "name": "Ital",
+          "description": "Ital az előkészítéshez"
+        },
+        "entity_id": {
+          "name": "Entitás azonosító",
+          "description": "A kávéfőző entitás azonosítója"
+        }
+      }
+    }
+  },
+  "selector": {
+    "beverage": {
+      "options": {
+        "none": "Egyik sem",
+        "steam": "Gőz",
+        "long": "Hosszú",
+        "coffee": "Kávé",
+        "dopio": "KETTŐS",
+        "hot_water": "Melegvíz",
+        "espresso": "Eszpresszó",
+        "americano": "Amerikai",
+        "espresso2": "Espresso 2"
+      }
+    }
+  }
+}

--- a/custom_components/delonghi_primadonna/translations/ja.json
+++ b/custom_components/delonghi_primadonna/translations/ja.json
@@ -1,0 +1,89 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "デバイスはすでに構成されています"
+    },
+    "error": {
+      "cannot_connect": "接続に失敗しました",
+      "invalid_auth": "無効な認証",
+      "unknown": "予期しないエラー"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "mac": "MAC",
+          "name": "名前"
+        }
+      }
+    }
+  },
+  "entity": {
+    "select": {
+      "profile": {
+        "name": "プロフィール"
+      },
+      "make_beverage": {
+        "name": "飲み物"
+      },
+      "energy_save_mode": {
+        "name": "その後オフにします"
+      },
+      "water_hardness": {
+        "name": "水の硬度"
+      },
+      "water_temperature": {
+        "name": "水温"
+      }
+    },
+    "button": {
+      "power_on": {
+        "name": "オンにする"
+      }
+    },
+    "switch": {
+      "cup_light": {
+        "name": "カップライト"
+      },
+      "debug_notification": {
+        "name": "デバッグ通知"
+      },
+      "energy_save_mode": {
+        "name": "エネルギー保存モード"
+      },
+      "sounds": {
+        "name": "音"
+      }
+    }
+  },
+  "services": {
+    "make_beverage": {
+      "name": "飲み物を作ります",
+      "description": "以下のリストから飲み物を準備してください",
+      "fields": {
+        "beverage": {
+          "name": "飲み物",
+          "description": "準備する飲み物"
+        },
+        "entity_id": {
+          "name": "エンティティID",
+          "description": "コーヒーマシンのエンティティID"
+        }
+      }
+    }
+  },
+  "selector": {
+    "beverage": {
+      "options": {
+        "none": "なし",
+        "steam": "スチーム",
+        "long": "長さ",
+        "coffee": "コーヒー",
+        "dopio": "ダブル",
+        "hot_water": "お湯",
+        "espresso": "エスプレッソ",
+        "americano": "アメリカーノ",
+        "espresso2": "エスプレッソ2"
+      }
+    }
+  }
+}

--- a/custom_components/delonghi_primadonna/translations/ko.json
+++ b/custom_components/delonghi_primadonna/translations/ko.json
@@ -1,0 +1,89 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "장치는 이미 구성되어 있습니다"
+    },
+    "error": {
+      "cannot_connect": "연결하지 못했습니다",
+      "invalid_auth": "잘못된 인증",
+      "unknown": "예상치 못한 오류"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "mac": "MAC",
+          "name": "이름"
+        }
+      }
+    }
+  },
+  "entity": {
+    "select": {
+      "profile": {
+        "name": "윤곽"
+      },
+      "make_beverage": {
+        "name": "음료"
+      },
+      "energy_save_mode": {
+        "name": "후에 꺼집니다"
+      },
+      "water_hardness": {
+        "name": "물 경도"
+      },
+      "water_temperature": {
+        "name": "수온"
+      }
+    },
+    "button": {
+      "power_on": {
+        "name": "켜십시오"
+      }
+    },
+    "switch": {
+      "cup_light": {
+        "name": "컵 라이트"
+      },
+      "debug_notification": {
+        "name": "디버그 알림"
+      },
+      "energy_save_mode": {
+        "name": "에너지 저장 모드"
+      },
+      "sounds": {
+        "name": "소리"
+      }
+    }
+  },
+  "services": {
+    "make_beverage": {
+      "name": "음료를 만드십시오",
+      "description": "아래 목록에서 음료를 준비하십시오",
+      "fields": {
+        "beverage": {
+          "name": "음료",
+          "description": "준비 할 음료"
+        },
+        "entity_id": {
+          "name": "엔티티 ID",
+          "description": "커피 머신의 엔티티 ID"
+        }
+      }
+    }
+  },
+  "selector": {
+    "beverage": {
+      "options": {
+        "none": "없음",
+        "steam": "증기",
+        "long": "긴",
+        "coffee": "커피",
+        "dopio": "더블",
+        "hot_water": "뜨거운 물",
+        "espresso": "에스프레소 커피",
+        "americano": "아메리카노",
+        "espresso2": "에스프레소 2"
+      }
+    }
+  }
+}

--- a/custom_components/delonghi_primadonna/translations/ro.json
+++ b/custom_components/delonghi_primadonna/translations/ro.json
@@ -1,0 +1,89 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "Dispozitivul este deja configurat"
+    },
+    "error": {
+      "cannot_connect": "Nu a reușit să se conecteze",
+      "invalid_auth": "Autentificare nevalide",
+      "unknown": "Eroare neașteptată"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "mac": "MAC",
+          "name": "Nume"
+        }
+      }
+    }
+  },
+  "entity": {
+    "select": {
+      "profile": {
+        "name": "Profil"
+      },
+      "make_beverage": {
+        "name": "Băutură"
+      },
+      "energy_save_mode": {
+        "name": "Opriți după"
+      },
+      "water_hardness": {
+        "name": "Duritatea apei"
+      },
+      "water_temperature": {
+        "name": "Temperatura apei"
+      }
+    },
+    "button": {
+      "power_on": {
+        "name": "Porniți"
+      }
+    },
+    "switch": {
+      "cup_light": {
+        "name": "Cupă lumină"
+      },
+      "debug_notification": {
+        "name": "Notificare de depanare"
+      },
+      "energy_save_mode": {
+        "name": "Mod de economisire a energiei"
+      },
+      "sounds": {
+        "name": "Sunete"
+      }
+    }
+  },
+  "services": {
+    "make_beverage": {
+      "name": "Faceți băuturi",
+      "description": "Pregătiți o băutură din lista de mai jos",
+      "fields": {
+        "beverage": {
+          "name": "Băutură",
+          "description": "Băutură de pregătit"
+        },
+        "entity_id": {
+          "name": "ID de entitate",
+          "description": "ID de entitate a mașinii de cafea"
+        }
+      }
+    }
+  },
+  "selector": {
+    "beverage": {
+      "options": {
+        "none": "Nici unul",
+        "steam": "Aburi",
+        "long": "Lung",
+        "coffee": "Cafea",
+        "dopio": "DUBLA",
+        "hot_water": "Apă caldă",
+        "espresso": "Espresso",
+        "americano": "Americano",
+        "espresso2": "Espresso 2"
+      }
+    }
+  }
+}

--- a/custom_components/delonghi_primadonna/translations/zh-Hans.json
+++ b/custom_components/delonghi_primadonna/translations/zh-Hans.json
@@ -1,0 +1,89 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "设备已经配置"
+    },
+    "error": {
+      "cannot_connect": "无法连接",
+      "invalid_auth": "无效的身份验证",
+      "unknown": "意外错误"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "mac": "MAC",
+          "name": "名称"
+        }
+      }
+    }
+  },
+  "entity": {
+    "select": {
+      "profile": {
+        "name": "轮廓"
+      },
+      "make_beverage": {
+        "name": "饮料"
+      },
+      "energy_save_mode": {
+        "name": "之后关闭"
+      },
+      "water_hardness": {
+        "name": "水硬度"
+      },
+      "water_temperature": {
+        "name": "水温"
+      }
+    },
+    "button": {
+      "power_on": {
+        "name": "打开"
+      }
+    },
+    "switch": {
+      "cup_light": {
+        "name": "杯灯"
+      },
+      "debug_notification": {
+        "name": "调试通知"
+      },
+      "energy_save_mode": {
+        "name": "节能模式"
+      },
+      "sounds": {
+        "name": "听起来"
+      }
+    }
+  },
+  "services": {
+    "make_beverage": {
+      "name": "制作饮料",
+      "description": "从下面的列表中准备饮料",
+      "fields": {
+        "beverage": {
+          "name": "饮料",
+          "description": "准备饮料"
+        },
+        "entity_id": {
+          "name": "实体ID",
+          "description": "咖啡机的实体ID"
+        }
+      }
+    }
+  },
+  "selector": {
+    "beverage": {
+      "options": {
+        "none": "没有任何",
+        "steam": "蒸汽",
+        "long": "长的",
+        "coffee": "咖啡",
+        "dopio": "双倍的",
+        "hot_water": "热水",
+        "espresso": "浓缩咖啡",
+        "americano": "美国",
+        "espresso2": "浓缩咖啡2"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Romanian, Hungarian, Japanese, Korean and Simplified Chinese translations
- update German and French translations to include all strings
- keep MAC label untranslated across new languages

## Testing
- `flake8 .`


------
https://chatgpt.com/codex/tasks/task_e_6845680652588320b96d01471cc0c6f3

## Summary by Sourcery

Enhancements:
- Add translations for Romanian, Hungarian, Japanese, Korean, and Simplified Chinese; update German and French to cover all strings; and preserve the MAC label in English.