### PR TITLE
Restore indicator state on load

### DIFF
--- a/custom_components/delonghi_primadonna/__init__.py
+++ b/custom_components/delonghi_primadonna/__init__.py
@@ -34,6 +34,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     delonghi_device = DelongiPrimadonna(entry.data, hass)
     hass.data[DOMAIN][entry.unique_id] = delonghi_device
     _LOGGER.debug('Device id %s', entry.unique_id)
+
+    hass.async_create_task(delonghi_device.get_device_name())
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     async def make_beverage(call: ServiceCall) -> None:

--- a/custom_components/delonghi_primadonna/binary_sensor.py
+++ b/custom_components/delonghi_primadonna/binary_sensor.py
@@ -4,6 +4,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import DOMAIN
 from .device import DelonghiDeviceEntity
@@ -25,7 +26,9 @@ async def async_setup_entry(
     return True
 
 
-class DelongiPrimadonnaEnabledSensor(DelonghiDeviceEntity, BinarySensorEntity):
+class DelongiPrimadonnaEnabledSensor(
+    DelonghiDeviceEntity, BinarySensorEntity, RestoreEntity
+):
     """
     Shows if the device up and running
     """
@@ -33,6 +36,12 @@ class DelongiPrimadonnaEnabledSensor(DelonghiDeviceEntity, BinarySensorEntity):
     _attr_device_class = BinarySensorDeviceClass.RUNNING
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_name = 'Enabled'
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        if (last_state := await self.async_get_last_state()) is not None:
+            self._attr_is_on = last_state.state == 'on'
+            self.device.switches.is_on = self._attr_is_on
 
     @property
     def icon(self) -> str:
@@ -52,7 +61,9 @@ class DelongiPrimadonnaEnabledSensor(DelonghiDeviceEntity, BinarySensorEntity):
         return self.device.switches.is_on
 
 
-class DelongiPrimadonnaDescaleSensor(DelonghiDeviceEntity, BinarySensorEntity):
+class DelongiPrimadonnaDescaleSensor(
+    DelonghiDeviceEntity, BinarySensorEntity, RestoreEntity
+):
     """
     Shows if the device needs descaling
     """
@@ -61,12 +72,19 @@ class DelongiPrimadonnaDescaleSensor(DelonghiDeviceEntity, BinarySensorEntity):
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_name = 'Descaling'
 
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        if (last_state := await self.async_get_last_state()) is not None:
+            self._attr_is_on = last_state.state == 'on'
+
     @property
     def native_value(self):
         return self.device.service
 
     @property
     def is_on(self) -> bool:
+        if (is_on := getattr(self, '_attr_is_on', None)) is not None:
+            return is_on
         return bool((self.device.service >> 2) % 2)
 
     @property
@@ -77,7 +95,9 @@ class DelongiPrimadonnaDescaleSensor(DelonghiDeviceEntity, BinarySensorEntity):
         return result
 
 
-class DelongiPrimadonnaFilterSensor(DelonghiDeviceEntity, BinarySensorEntity):
+class DelongiPrimadonnaFilterSensor(
+    DelonghiDeviceEntity, BinarySensorEntity, RestoreEntity
+):
     """
     Shows if the filter need to be changed
     """
@@ -86,12 +106,19 @@ class DelongiPrimadonnaFilterSensor(DelonghiDeviceEntity, BinarySensorEntity):
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_name = 'Filter'
 
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        if (last_state := await self.async_get_last_state()) is not None:
+            self._attr_is_on = last_state.state == 'on'
+
     @property
     def native_value(self):
         return self.device.service
 
     @property
     def is_on(self) -> bool:
+        if (is_on := getattr(self, '_attr_is_on', None)) is not None:
+            return is_on
         return bool((self.device.service >> 3) % 2)
 
     @property

--- a/custom_components/delonghi_primadonna/select.py
+++ b/custom_components/delonghi_primadonna/select.py
@@ -6,6 +6,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import AVAILABLE_PROFILES, DOMAIN, POWER_OFF_OPTIONS
 from .device import (AvailableBeverage, BeverageEntityFeature,
@@ -32,7 +33,7 @@ async def async_setup_entry(
     return True
 
 
-class ProfileSelect(DelonghiDeviceEntity, SelectEntity):
+class ProfileSelect(DelonghiDeviceEntity, SelectEntity, RestoreEntity):
     """Implementation for profile selection."""
 
     _attr_options = list(AVAILABLE_PROFILES.keys())
@@ -40,6 +41,11 @@ class ProfileSelect(DelonghiDeviceEntity, SelectEntity):
     _attr_entity_category = EntityCategory.CONFIG
     _attr_translation_key = 'profile'
     _attr_icon = 'mdi:account'
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        if (last_state := await self.async_get_last_state()) is not None:
+            self._attr_current_option = last_state.state
 
     @property
     def entity_category(self, **kwargs: Any) -> None:
@@ -53,7 +59,7 @@ class ProfileSelect(DelonghiDeviceEntity, SelectEntity):
         self._attr_current_option = option
 
 
-class BeverageSelect(DelonghiDeviceEntity, SelectEntity):
+class BeverageSelect(DelonghiDeviceEntity, SelectEntity, RestoreEntity):
     """Beverage start implementation by the select"""
 
     _attr_options = [*AvailableBeverage]
@@ -63,12 +69,17 @@ class BeverageSelect(DelonghiDeviceEntity, SelectEntity):
     _attr_supported_features: BeverageEntityFeature \
         = BeverageEntityFeature.MAKE_BEVERAGE
 
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        if (last_state := await self.async_get_last_state()) is not None:
+            self._attr_current_option = last_state.state
+
     async def async_select_option(self, option: str) -> None:
         """Select beverage action"""
         self.hass.async_create_task(self.device.beverage_start(option))
 
 
-class EnergySaveModeSelect(DelonghiDeviceEntity, SelectEntity):
+class EnergySaveModeSelect(DelonghiDeviceEntity, SelectEntity, RestoreEntity):
     """Energy save mode management"""
 
     _attr_options = list(POWER_OFF_OPTIONS.keys())
@@ -81,6 +92,11 @@ class EnergySaveModeSelect(DelonghiDeviceEntity, SelectEntity):
         """Return the category of the entity."""
         return EntityCategory.CONFIG
 
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        if (last_state := await self.async_get_last_state()) is not None:
+            self._attr_current_option = last_state.state
+
     async def async_select_option(self, option: str) -> None:
         """Select energy save mode action"""
         power_off_interval = POWER_OFF_OPTIONS.get(option)
@@ -90,13 +106,18 @@ class EnergySaveModeSelect(DelonghiDeviceEntity, SelectEntity):
         self._attr_current_option = option
 
 
-class WaterHardnessSelect(DelonghiDeviceEntity, SelectEntity):
+class WaterHardnessSelect(DelonghiDeviceEntity, SelectEntity, RestoreEntity):
     """Water hardness management"""
 
     _attr_options = ['Soft', 'Medium', 'Hard', 'Very Hard']
     _attr_current_option = 'Soft'
     _attr_translation_key = 'water_hardness'
     _attr_icon = 'mdi:water'
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        if (last_state := await self.async_get_last_state()) is not None:
+            self._attr_current_option = last_state.state
 
     @property
     def entity_category(self, **kwargs: Any) -> None:
@@ -112,7 +133,9 @@ class WaterHardnessSelect(DelonghiDeviceEntity, SelectEntity):
         self._attr_current_option = option
 
 
-class WaterTemperatureSelect(DelonghiDeviceEntity, SelectEntity):
+class WaterTemperatureSelect(
+    DelonghiDeviceEntity, SelectEntity, RestoreEntity
+):
     """Water temperature management"""
 
     _attr_options = ['Low', 'Medium', 'High', 'Highest']
@@ -120,6 +143,11 @@ class WaterTemperatureSelect(DelonghiDeviceEntity, SelectEntity):
     _attr_translation_key = 'water_temperature'
     _attr_icon = 'mdi:thermometer'
     _attr_supported_features: BeverageEntityFeature = BeverageEntityFeature(1)
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        if (last_state := await self.async_get_last_state()) is not None:
+            self._attr_current_option = last_state.state
 
     @property
     def entity_category(self, **kwargs: Any) -> None:

--- a/custom_components/delonghi_primadonna/sensor.py
+++ b/custom_components/delonghi_primadonna/sensor.py
@@ -5,6 +5,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import DOMAIN
 from .device import DEVICE_STATUS, NOZZLE_STATE, DelonghiDeviceEntity
@@ -25,7 +26,9 @@ async def async_setup_entry(
     return True
 
 
-class DelongiPrimadonnaNozzleSensor(DelonghiDeviceEntity, SensorEntity):
+class DelongiPrimadonnaNozzleSensor(
+    DelonghiDeviceEntity, SensorEntity, RestoreEntity
+):
     """
     Check the connected steam nozzle
     Steam or milk pot
@@ -36,6 +39,11 @@ class DelongiPrimadonnaNozzleSensor(DelonghiDeviceEntity, SensorEntity):
     _attr_name = 'Nozzle'
 
     _attr_options = list(NOZZLE_STATE.values())
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        if (last_state := await self.async_get_last_state()) is not None:
+            self._attr_native_value = last_state.state
 
     @property
     def native_value(self):
@@ -56,7 +64,9 @@ class DelongiPrimadonnaNozzleSensor(DelonghiDeviceEntity, SensorEntity):
         return result
 
 
-class DelongiPrimadonnaStatusSensor(DelonghiDeviceEntity, SensorEntity):
+class DelongiPrimadonnaStatusSensor(
+    DelonghiDeviceEntity, SensorEntity, RestoreEntity
+):
     """
     Shows the actual device status
     """
@@ -65,6 +75,11 @@ class DelongiPrimadonnaStatusSensor(DelonghiDeviceEntity, SensorEntity):
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_name = 'Status'
     _attr_options = list(DEVICE_STATUS.values())
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        if (last_state := await self.async_get_last_state()) is not None:
+            self._attr_native_value = last_state.state
 
     @property
     def native_value(self):

--- a/custom_components/delonghi_primadonna/switch.py
+++ b/custom_components/delonghi_primadonna/switch.py
@@ -5,6 +5,7 @@ from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import DOMAIN
 from .device import DelonghiDeviceEntity
@@ -27,12 +28,19 @@ async def async_setup_entry(
     return True
 
 
-class DelongiPrimadonnaCupLightSwitch(DelonghiDeviceEntity, ToggleEntity):
+class DelongiPrimadonnaCupLightSwitch(
+    DelonghiDeviceEntity, ToggleEntity, RestoreEntity
+):
     """This switch enable/disable the cup light"""
 
     _attr_is_on = False
     _attr_icon = 'mdi:lightbulb'
     _attr_translation_key = 'cup_light'
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        if (last_state := await self.async_get_last_state()) is not None:
+            self._attr_is_on = last_state.state == 'on'
 
     @property
     def entity_category(self, **kwargs: Any) -> None:
@@ -50,7 +58,9 @@ class DelongiPrimadonnaCupLightSwitch(DelonghiDeviceEntity, ToggleEntity):
         self._attr_is_on = False
 
 
-class DelongiPrimadonnaNotificationSwitch(DelonghiDeviceEntity, ToggleEntity):
+class DelongiPrimadonnaNotificationSwitch(
+    DelonghiDeviceEntity, ToggleEntity, RestoreEntity
+):
     """This switch enable HA side bar notification
        on device status change used for debug purposes
     """
@@ -58,6 +68,11 @@ class DelongiPrimadonnaNotificationSwitch(DelonghiDeviceEntity, ToggleEntity):
     _attr_is_on = False
     _attr_icon = 'mdi:magnify-expand'
     _attr_translation_key = 'debug_notification'
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        if (last_state := await self.async_get_last_state()) is not None:
+            self.device.notify = last_state.state == 'on'
 
     @property
     def is_on(self, **kwargs: Any) -> None:
@@ -78,11 +93,18 @@ class DelongiPrimadonnaNotificationSwitch(DelonghiDeviceEntity, ToggleEntity):
         self.device.notify = False
 
 
-class DelongiPrimadonnaPowerSaveSwitch(DelonghiDeviceEntity, ToggleEntity):
+class DelongiPrimadonnaPowerSaveSwitch(
+    DelonghiDeviceEntity, ToggleEntity, RestoreEntity
+):
 
     _attr_is_on = False
     _attr_icon = 'mdi:lightning-bolt'
     _attr_translation_key = 'energy_save_mode'
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        if (last_state := await self.async_get_last_state()) is not None:
+            self._attr_is_on = last_state.state == 'on'
 
     @property
     def entity_category(self, **kwargs: Any) -> None:
@@ -100,11 +122,18 @@ class DelongiPrimadonnaPowerSaveSwitch(DelonghiDeviceEntity, ToggleEntity):
         self._attr_is_on = False
 
 
-class DelongiPrimadonnaSoundsSwitch(DelonghiDeviceEntity, ToggleEntity):
+class DelongiPrimadonnaSoundsSwitch(
+    DelonghiDeviceEntity, ToggleEntity, RestoreEntity
+):
 
     _attr_is_on = False
     _attr_icon = 'mdi:volume-high'
     _attr_translation_key = 'sounds'
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        if (last_state := await self.async_get_last_state()) is not None:
+            self._attr_is_on = last_state.state == 'on'
 
     @property
     def entity_category(self, **kwargs: Any) -> None:


### PR DESCRIPTION
## Summary
- fetch device configuration on startup
- restore sensor, switch and select states using `RestoreEntity`

## Testing
- `python -m flake8 custom_components`
- `isort --diff --check-only custom_components`

------
https://chatgpt.com/codex/tasks/task_e_684b4658a44c8320b5f0d500c4e262f5

## Summary by Sourcery

Restore previous HA entity states on startup and fetch device configuration on setup.

New Features:
- Fetch device configuration on Home Assistant startup

Enhancements:
- Add RestoreEntity mixin to binary sensors, selects, switches, and sensors to reinstate their last known state in async_added_to_hass