### PR TITLE
Update profiles to come from device

### DIFF
--- a/custom_components/delonghi_primadonna/device.py
+++ b/custom_components/delonghi_primadonna/device.py
@@ -14,8 +14,8 @@ from homeassistant.const import CONF_MAC, CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
-from .const import (AMERICANO_OFF, AMERICANO_ON, BASE_COMMAND,
-                    BYTES_AUTOPOWEROFF_COMMAND, BYTES_POWER,
+from .const import (AMERICANO_OFF, AMERICANO_ON, AVAILABLE_PROFILES,
+                    BASE_COMMAND, BYTES_AUTOPOWEROFF_COMMAND, BYTES_POWER,
                     BYTES_SWITCH_COMMAND, BYTES_WATER_HARDNESS_COMMAND,
                     BYTES_WATER_TEMPERATURE_COMMAND, COFFE_OFF, COFFE_ON,
                     COFFEE_GROUNDS_CONTAINER_DETACHED,
@@ -212,6 +212,7 @@ class DelongiPrimadonna:
         self.status = DEVICE_STATUS[5]
         self.switches = DeviceSwitches()
         self._lock = asyncio.Lock()
+        self.profiles = list(AVAILABLE_PROFILES.keys())
 
     async def disconnect(self):
         """Disconnect from the device."""

--- a/custom_components/delonghi_primadonna/select.py
+++ b/custom_components/delonghi_primadonna/select.py
@@ -36,11 +36,14 @@ async def async_setup_entry(
 class ProfileSelect(DelonghiDeviceEntity, SelectEntity, RestoreEntity):
     """Implementation for profile selection."""
 
-    _attr_options = list(AVAILABLE_PROFILES.keys())
-    _attr_current_option = list(AVAILABLE_PROFILES.keys())[0]
     _attr_entity_category = EntityCategory.CONFIG
     _attr_translation_key = 'profile'
     _attr_icon = 'mdi:account'
+
+    def __init__(self, delongh_device: DelongiPrimadonna, hass: HomeAssistant):
+        super().__init__(delongh_device, hass)
+        self._attr_options = delongh_device.profiles
+        self._attr_current_option = delongh_device.profiles[0]
 
     async def async_added_to_hass(self) -> None:
         await super().async_added_to_hass()


### PR DESCRIPTION
## Summary
- load profile options from the device object
- default device profiles to AVAILABLE_PROFILES

## Testing
- `isort --diff --check-only custom_components`
- `flake8 custom_components`


------
https://chatgpt.com/codex/tasks/task_e_684edb7acfd483209b58f9b29b4f4fa9

## Summary by Sourcery

Load profile options dynamically from the device and update the select entity to use those options

Enhancements:
- Populate device.profiles from AVAILABLE_PROFILES keys
- Configure ProfileSelect to initialize options and current option from the device’s profiles