### PR TITLE
Implement red icon coloring for problem sensors

### DIFF
--- a/custom_components/delonghi_primadonna/binary_sensor.py
+++ b/custom_components/delonghi_primadonna/binary_sensor.py
@@ -94,6 +94,10 @@ class DelongiPrimadonnaDescaleSensor(
             result = 'mdi:dishwasher-alert'
         return result
 
+    @property
+    def icon_color(self):
+        return 'red' if self.is_on else None
+
 
 class DelongiPrimadonnaFilterSensor(
     DelonghiDeviceEntity, BinarySensorEntity, RestoreEntity
@@ -127,3 +131,7 @@ class DelongiPrimadonnaFilterSensor(
         if self.is_on:
             result = 'mdi:filter-off'
         return result
+
+    @property
+    def icon_color(self):
+        return 'red' if self.is_on else None


### PR DESCRIPTION
## Summary
- highlight descaling and filter sensors when on

## Testing
- `isort .`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f26d31dd083209810265be5e0d4c7

## Summary by Sourcery

Highlight descaling and filter sensors by coloring their icons red when the sensor state is active

Enhancements:
- Add icon_color property to descaling sensor to display a red icon when active
- Add icon_color property to filter sensor to display a red icon when active