### PR TITLE
Display answerId in notification

### DIFF
--- a/custom_components/delonghi_primadonna/device.py
+++ b/custom_components/delonghi_primadonna/device.py
@@ -339,12 +339,13 @@ class DelongiPrimadonna:
         self._hass.bus.async_fire(f'{DOMAIN}_event', event_data)
 
         if self.notify:
+            answer_id = f"{value[2]:02x}"
             await self._hass.services.async_call(
                 'persistent_notification',
                 'create',
                 {
                     'message': notification_message,
-                    'title': f'{self.name} {self.mac}',
+                    'title': f'{self.name} {self.mac} {answer_id}',
                     'notification_id': f'{self.mac}_err_{uuid.uuid4()}',
                 },
             )


### PR DESCRIPTION
## Summary
- show the 3rd octet (`answerId`) in the persistent notification title

## Testing
- `pip install -r requirements_dev.txt`
- `isort --diff --check-only custom_components`
- `flake8 custom_components`


------
https://chatgpt.com/codex/tasks/task_e_684f2d0e5d008320b77f2aa71cd438c9