### PR TITLE
Update parsing in handle data

### DIFF
--- a/custom_components/delonghi_primadonna/device.py
+++ b/custom_components/delonghi_primadonna/device.py
@@ -381,18 +381,12 @@ class DelongiPrimadonna:
 
     async def _handle_data(self, sender, value):
         """Handle notifications from the device."""
-        value_len = len(value)
+        answer_id = value[2] if len(value) > 2 else None
 
-        if value_len > 9:
+        if answer_id == 0x75:
             self.switches.is_on = value[9] > 0
-
-        if value_len > 4:
             self.steam_nozzle = NOZZLE_STATE.get(value[4], value[4])
-
-        if value_len > 7:
             self.service = value[7]
-
-        if value_len > 5:
             self.status = DEVICE_STATUS.get(value[5], DEVICE_STATUS[5])
 
         hex_value = hexlify(value, ' ')


### PR DESCRIPTION
## Summary
- parse notifications only when `answerId` equals `0x75`

## Testing
- `flake8`
- `isort --check custom_components/delonghi_primadonna/device.py`

------
https://chatgpt.com/codex/tasks/task_e_684f35dade748320b096f6dc5b18b8e8

## Summary by Sourcery

Simplify the notification parsing in handle_data by extracting the answer ID, restricting switch state updates to 0x75 notifications, and removing redundant length checks for steam nozzle, service, and status updates.

Enhancements:
- Extract answer_id from the payload for parsing logic
- Only update switch state when answer_id equals 0x75
- Remove length-based guards and always update steam_nozzle, service, and status attributes