### PR TITLE
Add profile parsing on response 0xa4

### DIFF
--- a/custom_components/delonghi_primadonna/device.py
+++ b/custom_components/delonghi_primadonna/device.py
@@ -396,6 +396,19 @@ class DelongiPrimadonna:
             self.steam_nozzle = NOZZLE_STATE.get(value[4], value[4])
             self.service = value[7]
             self.status = DEVICE_STATUS.get(value[5], DEVICE_STATUS[5])
+        elif answer_id == 0xA4:
+            try:
+                parsed = self._parse_profile_response(list(value))
+            except Exception as err:  # noqa: BLE001
+                _LOGGER.warning("Failed to parse profile response: %s", err)
+            else:
+                for name, pid in parsed.items():
+                    for old_name, old_pid in list(AVAILABLE_PROFILES.items()):
+                        if old_pid == pid:
+                            AVAILABLE_PROFILES.pop(old_name)
+                            break
+                    AVAILABLE_PROFILES[name] = pid
+                self.profiles = list(AVAILABLE_PROFILES.keys())
 
         hex_value = hexlify(value, ' ')
 


### PR DESCRIPTION
## Summary
- handle profile responses in `_handle_data`
- update profile list by merging with defaults
- remove old entries with same profile ID before adding new

## Testing
- `isort custom_components/delonghi_primadonna/device.py`
- `flake8 custom_components/delonghi_primadonna/device.py`
- `pip install -r requirements_dev.txt`


------
https://chatgpt.com/codex/tasks/task_e_684f53074a4c832085120c740ed7339a

## Summary by Sourcery

Add support for parsing and updating device profiles from 0xA4 responses in the data handler

New Features:
- Parse profile response (0xA4) in `_handle_data` to extract profile IDs

Enhancements:
- Merge parsed profiles with the default list and remove duplicates by profile ID
- Update the `self.profiles` list and log a warning on parse failures