### PR TITLE
Improve profile change logging

### DIFF
--- a/custom_components/delonghi_primadonna/select.py
+++ b/custom_components/delonghi_primadonna/select.py
@@ -66,6 +66,7 @@ class ProfileSelect(DelonghiDeviceEntity, SelectEntity, RestoreEntity):
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         profile_id = AVAILABLE_PROFILES.get(option)
+        _LOGGER.debug("Select profile '%s' id=%s", option, profile_id)
         self.hass.async_create_task(self.device.select_profile(profile_id))
         self._attr_current_option = option
 


### PR DESCRIPTION
## Summary
- add detailed debug logs for request signing
- log profile commands and responses
- show selected profile id in UI handler

## Testing
- `isort --diff --check-only custom_components`
- `flake8 custom_components`

------
https://chatgpt.com/codex/tasks/task_e_684f5ef87ce083208b2cbb42867278c3

## Summary by Sourcery

Improve logging around request signing and profile selection by adding detailed debug and info messages for request payloads, signatures, commands, and responses to aid troubleshooting.

Enhancements:
- Log raw request data and signature bytes during message signing
- Log profile change responses with profile ID, status and raw payload
- Add debug logs when sending profile selection commands
- Add debug logs in UI handler for selected profile option and ID