### PR TITLE
Improve profile ID parsing

### DIFF
--- a/custom_components/delonghi_primadonna/device.py
+++ b/custom_components/delonghi_primadonna/device.py
@@ -459,18 +459,33 @@ class DelongiPrimadonna:
 
         profiles: dict[str, int] = {}
         offset = 0
-        current_id = start_id
-        while offset + 21 <= len(payload):
+        while offset + 16 <= len(payload):
             name_bytes = payload[offset:offset + 16]
-            name = name_bytes.decode("utf-16-be").rstrip("\x00").strip()
             offset += 16
-            offset += 4  # padding bytes
-            offset += 1  # skip id byte from payload
+            name = name_bytes.decode("utf-16-be").rstrip("\x00").strip()
+
+            # Skip padding zeros between name and the profile id
+            while offset < len(payload) and payload[offset] == 0x00:
+                offset += 1
+
+            if offset >= len(payload):
+                break
+
+            id_byte = payload[offset]
+            offset += 1
 
             if not name:
                 continue
-            profiles[name] = current_id
-            current_id += 1
+
+            if 0x30 <= id_byte <= 0x39:
+                profile_id = id_byte - 0x30
+            else:
+                profile_id = id_byte
+
+            profiles[name] = profile_id
+
+            while offset < len(payload) and payload[offset] == 0x00:
+                offset += 1
 
         _LOGGER.warning("Parsed profiles: %s", profiles)
         return profiles


### PR DESCRIPTION
## Summary
- parse profile IDs directly from payload instead of assuming sequential IDs

## Testing
- `isort custom_components/delonghi_primadonna/device.py`
- `flake8 custom_components/delonghi_primadonna/device.py`


------
https://chatgpt.com/codex/tasks/task_e_684fea5bb584832086d2c754b33b186e