### PR TITLE
Fix profile parser endianess

### DIFF
--- a/custom_components/delonghi_primadonna/device.py
+++ b/custom_components/delonghi_primadonna/device.py
@@ -459,10 +459,11 @@ class DelongiPrimadonna:
 
         profiles: dict[str, int] = {}
         offset = 0
-        while offset + 16 <= len(payload):
-            name_bytes = payload[offset:offset + 16]
-            offset += 16
-            name = name_bytes.decode("utf-16-be").rstrip("\x00").strip()
+        NAME_SIZE = 20
+        while offset + NAME_SIZE <= len(payload):
+            name_bytes = payload[offset:offset + NAME_SIZE]
+            offset += NAME_SIZE
+            name = name_bytes.decode("utf-16-le").rstrip("\x00").strip()
 
             # Skip padding zeros between name and the profile id
             while offset < len(payload) and payload[offset] == 0x00:


### PR DESCRIPTION
## Summary
- parse profile names as UTF-16-LE
- update name block size to fixed 20 bytes

## Testing
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_68501a25f8e08320ab37189d0ab104fc