### PR TITLE
Refactor profile mapping to use numeric keys

### DIFF
--- a/custom_components/delonghi_primadonna/const.py
+++ b/custom_components/delonghi_primadonna/const.py
@@ -13,11 +13,12 @@ DESCRIPTOR = '00002902-0000-1000-8000-00805f9b34fb'
 
 BEVERAGE_SERVICE_NAME = 'make_beverage'
 
+# Mapping of profile id to profile name
 AVAILABLE_PROFILES = {
-    'Profile 1': 1,
-    'Profile 2': 2,
-    'Profile 3': 3,
-    'Guest': 4
+    1: 'Profile 1',
+    2: 'Profile 2',
+    3: 'Profile 3',
+    4: 'Guest',
 }
 
 POWER_OFF_OPTIONS = {

--- a/custom_components/delonghi_primadonna/select.py
+++ b/custom_components/delonghi_primadonna/select.py
@@ -66,7 +66,11 @@ class ProfileSelect(DelonghiDeviceEntity, SelectEntity, RestoreEntity):
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         profile_id = next(
-            (pid for pid, name in AVAILABLE_PROFILES.items() if name == option),
+            (
+                pid
+                for pid, name in AVAILABLE_PROFILES.items()
+                if name == option
+            ),
             None,
         )
         _LOGGER.debug("Select profile '%s' id=%s", option, profile_id)

--- a/custom_components/delonghi_primadonna/select.py
+++ b/custom_components/delonghi_primadonna/select.py
@@ -65,7 +65,10 @@ class ProfileSelect(DelonghiDeviceEntity, SelectEntity, RestoreEntity):
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
-        profile_id = AVAILABLE_PROFILES.get(option)
+        profile_id = next(
+            (pid for pid, name in AVAILABLE_PROFILES.items() if name == option),
+            None,
+        )
         _LOGGER.debug("Select profile '%s' id=%s", option, profile_id)
         self.hass.async_create_task(self.device.select_profile(profile_id))
         self._attr_current_option = option


### PR DESCRIPTION
## Summary
- refactor `AVAILABLE_PROFILES` to use numeric keys instead of names
- adjust device profile parsing and storage
- update profile selection logic

## Testing
- `flake8 custom_components/delonghi_primadonna`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68526eb9b4808320bf995bd70fdd1ec5

## Summary by Sourcery

Refactor profile mapping to use numeric IDs and adjust related parsing and selection logic

Enhancements:
- Switch AVAILABLE_PROFILES to map numeric IDs to profile names
- Update profile response parsing to return ID-to-name mappings
- Adjust profile storage and selection workflows to use numeric keys