### PR TITLE
Add image entity

### DIFF
--- a/custom_components/delonghi_primadonna/__init__.py
+++ b/custom_components/delonghi_primadonna/__init__.py
@@ -13,6 +13,7 @@ from .const import BEVERAGE_SERVICE_NAME, DOMAIN
 from .device import AvailableBeverage, BeverageEntityFeature, DelongiPrimadonna
 
 PLATFORMS: list[str] = [
+    Platform.IMAGE,
     Platform.BUTTON,
     Platform.BINARY_SENSOR,
     Platform.SENSOR,

--- a/custom_components/delonghi_primadonna/const.py
+++ b/custom_components/delonghi_primadonna/const.py
@@ -11,6 +11,11 @@ NAME_CHARACTERISTIC = '00002A00-0000-1000-8000-00805F9B34FB'
 
 DESCRIPTOR = '00002902-0000-1000-8000-00805f9b34fb'
 
+DEFAULT_IMAGE_URL = (
+    'https://delonghibe.s3.eu-west-1.amazonaws.com/cms/prod/img/'
+    '_opt_delonghi_uploads_PD_CLASS_TOP_INT_ECAM550.85.MS.png'
+)
+
 BEVERAGE_SERVICE_NAME = 'make_beverage'
 
 # Mapping of profile id to profile name

--- a/custom_components/delonghi_primadonna/device.py
+++ b/custom_components/delonghi_primadonna/device.py
@@ -157,8 +157,6 @@ class DelonghiDeviceEntity:
 
     _attr_has_entity_name = True
 
-    _attr_entity_picture = "https://delonghibe.s3.eu-west-1.amazonaws.com/cms/prod/img/_opt_delonghi_uploads_PD_CLASS_TOP_INT_ECAM550.85.MS.png"
-
     def __init__(self, delongh_device, hass: HomeAssistant):
         """Init entity with the device"""
         self._attr_unique_id = (

--- a/custom_components/delonghi_primadonna/image.py
+++ b/custom_components/delonghi_primadonna/image.py
@@ -1,0 +1,28 @@
+"""Image entity for Delonghi Primadonna."""
+
+from homeassistant.components.image import ImageEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DEFAULT_IMAGE_URL, DOMAIN
+from .device import DelonghiDeviceEntity, DelongiPrimadonna
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+):
+    """Set up image entity for a config entry."""
+
+    delongh_device: DelongiPrimadonna = hass.data[DOMAIN][entry.unique_id]
+    async_add_entities([DelongiPrimadonnaImage(delongh_device, hass)])
+    return True
+
+
+class DelongiPrimadonnaImage(DelonghiDeviceEntity, ImageEntity):
+    """Image entity showing a picture of the device."""
+
+    _attr_image_url = DEFAULT_IMAGE_URL
+    _attr_name = "Image"


### PR DESCRIPTION
## Summary
- add DEFAULT_IMAGE_URL constant
- create ImageEntity to show device picture
- register the image entity platform at setup
- remove entity picture attribute from base entity

## Testing
- `isort custom_components/delonghi_primadonna/*.py`
- `flake8 custom_components`


------
https://chatgpt.com/codex/tasks/task_e_6854757391588320b3ee445f1886fe39

## Summary by Sourcery

Add an image entity to display the Delonghi device picture using a default URL and register it during setup, and remove the hardcoded picture attribute from the base entity

New Features:
- Introduce DEFAULT_IMAGE_URL constant for the device image
- Create DelongiPrimadonnaImage subclass of ImageEntity to show the device picture
- Register the image entity platform in async_setup_entry

Enhancements:
- Remove the hardcoded _attr_entity_picture from the base device entity class