### PR TITLE
Fix ImageEntity initialization

### DIFF
--- a/custom_components/delonghi_primadonna/device.py
+++ b/custom_components/delonghi_primadonna/device.py
@@ -13,8 +13,6 @@ from homeassistant.components import bluetooth
 from homeassistant.const import CONF_MAC, CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
-import json
-import os
 
 from .const import (AMERICANO_OFF, AMERICANO_ON, AVAILABLE_PROFILES,
                     BASE_COMMAND, BYTES_AUTOPOWEROFF_COMMAND,
@@ -458,7 +456,10 @@ class DelongiPrimadonna:
         while idx + NAME_SIZE < len(b):
             profiles.setdefault(
                 profile_index,
-                b[idx:idx + NAME_SIZE].decode("utf-16-be").rstrip("\x00").strip(),
+                b[idx:idx + NAME_SIZE]
+                .decode("utf-16-be")
+                .rstrip("\x00")
+                .strip(),
             )
             profile_index += 1
             idx += NAME_SIZE + NAME_OFFSET

--- a/custom_components/delonghi_primadonna/image.py
+++ b/custom_components/delonghi_primadonna/image.py
@@ -26,3 +26,10 @@ class DelongiPrimadonnaImage(DelonghiDeviceEntity, ImageEntity):
 
     _attr_image_url = DEFAULT_IMAGE_URL
     _attr_name = "Image"
+
+    def __init__(
+        self, delongh_device: DelongiPrimadonna, hass: HomeAssistant
+    ) -> None:
+        """Initialize the image entity."""
+        DelonghiDeviceEntity.__init__(self, delongh_device, hass)
+        ImageEntity.__init__(self, hass)


### PR DESCRIPTION
## Summary
- initialize `ImageEntity` base in `DelongiPrimadonnaImage`
- fix flake8 warnings and line wrapping

## Testing
- `flake8 custom_components/delonghi_primadonna/device.py custom_components/delonghi_primadonna/image.py`
- `isort --diff --check-only custom_components/delonghi_primadonna/device.py custom_components/delonghi_primadonna/image.py`


------
https://chatgpt.com/codex/tasks/task_e_68547c85d7a4832096bbcae6f5409bab

## Summary by Sourcery

Initialize the ImageEntity base in DelongiPrimadonnaImage for correct setup and reformat parser decoding logic to comply with flake8

Bug Fixes:
- Ensure DelongiPrimadonnaImage properly initializes its ImageEntity base class

Enhancements:
- Resolve flake8 warnings by adjusting line wrapping in the profile response parser