### PR TITLE
Add model utils and refactor config flow

### DIFF
--- a/custom_components/delonghi_primadonna/config_flow.py
+++ b/custom_components/delonghi_primadonna/config_flow.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-import json
 import logging
-from importlib import resources
 from typing import Any
 
 import voluptuous
@@ -12,38 +10,17 @@ from homeassistant import config_entries
 from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
 from homeassistant.const import CONF_MAC, CONF_MODEL, CONF_NAME
 from homeassistant.data_entry_flow import FlowResult
-from homeassistant.helpers.selector import (SelectOptionDict, SelectSelector,
+from homeassistant.helpers.selector import (SelectSelector,
                                             SelectSelectorConfig,
                                             SelectSelectorMode)
 
 from .const import DOMAIN
+from .model import get_model_options
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def _load_model_options() -> list[SelectOptionDict]:
-    """Load machine models from bundled JSON."""
-    options: list[SelectOptionDict] = []
-    try:
-        with resources.files(__package__).joinpath("MachinesModels.json").open(
-            "r", encoding="utf-8"
-        ) as file:
-            data = json.load(file)
-    except Exception as err:  # pragma: no cover
-        _LOGGER.error("Failed to load machine models: %s", err)
-        return options
-
-    for machine in filter(
-        lambda m: m.get("connectionType") == "BT", data.get("machines", [])
-    ):
-        name = machine.get("name")
-        code = machine.get("product_code")
-        if name and code:
-            options.append(SelectOptionDict(value=code, label=name))
-    return options
-
-
-MODEL_OPTIONS = _load_model_options()
+MODEL_OPTIONS = get_model_options()
 
 STEP_USER_DATA_SCHEMA = voluptuous.Schema(
     {

--- a/custom_components/delonghi_primadonna/model.py
+++ b/custom_components/delonghi_primadonna/model.py
@@ -1,0 +1,48 @@
+"""Utilities for machine model data."""
+
+from __future__ import annotations
+
+import json
+import logging
+from functools import lru_cache
+from importlib import resources
+from typing import Any
+
+from homeassistant.helpers.selector import SelectOptionDict
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@lru_cache
+def _load_machines() -> list[dict[str, Any]]:
+    """Load machine models from bundled JSON."""
+    try:
+        with resources.files(__package__).joinpath("MachinesModels.json").open(
+            "r", encoding="utf-8"
+        ) as file:
+            data = json.load(file)
+        return data.get("machines", [])
+    except Exception as err:  # pragma: no cover
+        _LOGGER.error("Failed to load machine models: %s", err)
+        return []
+
+
+def get_model(product_code: str) -> dict[str, Any] | None:
+    """Return attributes for a model by product code."""
+    for machine in _load_machines():
+        if machine.get("product_code") == product_code:
+            return machine
+    return None
+
+
+def get_model_options(connection_type: str = "BT") -> list[SelectOptionDict]:
+    """Return selector options for models of the given connection type."""
+    options: list[SelectOptionDict] = []
+    for machine in filter(
+        lambda m: m.get("connectionType") == connection_type, _load_machines()
+    ):
+        name = machine.get("name")
+        code = machine.get("product_code")
+        if name and code:
+            options.append(SelectOptionDict(value=code, label=name))
+    return options


### PR DESCRIPTION
## Summary
- add `model.py` with helpers to load machine models
- refactor `config_flow.py` to use the new helpers

## Testing
- `flake8 custom_components | head -n 20`
- `isort --check-only custom_components > /tmp/isort.log && tail -n 20 /tmp/isort.log`

------
https://chatgpt.com/codex/tasks/task_e_68548c8789a883208dac276c32696b4c

## Summary by Sourcery

Factor out machine model JSON loading into a dedicated module with caching and retrieval helpers, and update the configuration flow to use these utilities for model selection.

New Features:
- Add model utilities module with functions to load machine definitions and retrieve model details

Enhancements:
- Refactor config flow to use new model utilities for loading options
- Introduce caching for loaded machine models to avoid repeated JSON parsing
- Add function to generate selector options filtered by connection type