### PR TITLE
Add product model image support

### DIFF
--- a/custom_components/delonghi_primadonna/image.py
+++ b/custom_components/delonghi_primadonna/image.py
@@ -7,6 +7,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DEFAULT_IMAGE_URL, DOMAIN
 from .device import DelonghiDeviceEntity, DelongiPrimadonna
+from .model import get_model
 
 
 async def async_setup_entry(
@@ -33,3 +34,8 @@ class DelongiPrimadonnaImage(DelonghiDeviceEntity, ImageEntity):
         """Initialize the image entity."""
         DelonghiDeviceEntity.__init__(self, delongh_device, hass)
         ImageEntity.__init__(self, hass)
+        model = get_model(delongh_device.product_code)
+        if model is not None:
+            url = model.get("image_url")
+            if url:
+                self._attr_image_url = url


### PR DESCRIPTION
## Summary
- set `DelongiPrimadonnaImage` URL using the configured product code

## Testing
- `isort custom_components/delonghi_primadonna/image.py`
- `flake8 custom_components/delonghi_primadonna/image.py`


------
https://chatgpt.com/codex/tasks/task_e_68548fb449748320829205128b317c32

## Summary by Sourcery

Enhancements:
- Set the DelongiPrimadonnaImage entity to use model-specific image URLs based on the product code