### PR TITLE
Fix CONF_MODEL import

### DIFF
--- a/custom_components/delonghi_primadonna/device.py
+++ b/custom_components/delonghi_primadonna/device.py
@@ -10,7 +10,7 @@ from enum import IntFlag
 from bleak import BleakClient
 from bleak.exc import BleakDBusError, BleakError
 from homeassistant.components import bluetooth
-from homeassistant.const import CONF_MAC, CONF_NAME
+from homeassistant.const import CONF_MAC, CONF_MODEL, CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
@@ -20,11 +20,10 @@ from .const import (AMERICANO_OFF, AMERICANO_ON, AVAILABLE_PROFILES,
                     BYTES_WATER_HARDNESS_COMMAND,
                     BYTES_WATER_TEMPERATURE_COMMAND, COFFE_OFF, COFFE_ON,
                     COFFEE_GROUNDS_CONTAINER_DETACHED,
-                    COFFEE_GROUNDS_CONTAINER_FULL, CONF_MODEL,
-                    CONTROLL_CHARACTERISTIC, DEBUG, DEVICE_READY,
-                    DEVICE_TURNOFF, DOMAIN, DOPPIO_OFF, DOPPIO_ON,
-                    ESPRESSO2_OFF, ESPRESSO2_ON, ESPRESSO_OFF, ESPRESSO_ON,
-                    HOTWATER_OFF, HOTWATER_ON, LONG_OFF, LONG_ON,
+                    COFFEE_GROUNDS_CONTAINER_FULL, CONTROLL_CHARACTERISTIC,
+                    DEBUG, DEVICE_READY, DEVICE_TURNOFF, DOMAIN, DOPPIO_OFF,
+                    DOPPIO_ON, ESPRESSO2_OFF, ESPRESSO2_ON, ESPRESSO_OFF,
+                    ESPRESSO_ON, HOTWATER_OFF, HOTWATER_ON, LONG_OFF, LONG_ON,
                     NAME_CHARACTERISTIC, START_COFFEE, STEAM_OFF, STEAM_ON,
                     WATER_SHORTAGE, WATER_TANK_DETACHED)
 


### PR DESCRIPTION
## Summary
- fix import for CONF_MODEL in device

## Testing
- `flake8 custom_components`
- `isort --diff --check-only custom_components`

------
https://chatgpt.com/codex/tasks/task_e_6854974107988320ac373b08e4b3ba73

## Summary by Sourcery

Bug Fixes:
- Remove incorrect CONF_MODEL import from the device module to resolve import errors