### PR TITLE
Add reconfiguration options flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Copy all files from this repository in custom_components/delonghi_primadonna to 
 * Enter "Delonghi"
 * Select "Delonghi Primadonna" integration
 * Enter the name and the MAC address
+* To change these settings later open the integration options and update the
+  values
 
 ![Charts](./images/image.png)
 

--- a/custom_components/delonghi_primadonna/__init__.py
+++ b/custom_components/delonghi_primadonna/__init__.py
@@ -69,3 +69,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.data[DOMAIN].pop(entry.unique_id)
     _LOGGER.debug('Unload %s', entry.unique_id)
     return unload_ok
+
+
+async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Reload the Delonghi entry."""
+
+    await async_unload_entry(hass, entry)
+    await async_setup_entry(hass, entry)

--- a/custom_components/delonghi_primadonna/config_flow.py
+++ b/custom_components/delonghi_primadonna/config_flow.py
@@ -101,3 +101,58 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 title=user_input[CONF_NAME],
                 data=user_input,
             )
+
+
+class OptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle options for existing entry."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        """Initialize options flow."""
+        self.config_entry = config_entry
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Manage the Delonghi configuration."""
+
+        if user_input is None:
+            data = self.config_entry.data
+            return self.async_show_form(
+                step_id="init",
+                data_schema=voluptuous.Schema(
+                    {
+                        voluptuous.Required(
+                            CONF_NAME, default=data.get(CONF_NAME)
+                        ): str,
+                        voluptuous.Required(
+                            CONF_MAC, default=data.get(CONF_MAC)
+                        ): str,
+                        voluptuous.Required(
+                            CONF_MODEL, default=data.get(CONF_MODEL)
+                        ): SelectSelector(
+                            SelectSelectorConfig(
+                                options=MODEL_OPTIONS,
+                                mode=SelectSelectorMode.DROPDOWN,
+                                sort=True,
+                            )
+                        ),
+                    }
+                ),
+            )
+
+        await self.hass.config_entries.async_update_entry(
+            self.config_entry,
+            data=user_input,
+        )
+        self.hass.async_create_task(
+            self.hass.config_entries.async_reload(self.config_entry.entry_id)
+        )
+        return self.async_create_entry(title="", data={})
+
+
+async def async_get_options_flow(
+    config_entry: config_entries.ConfigEntry,
+) -> OptionsFlowHandler:
+    """Return the options flow handler."""
+
+    return OptionsFlowHandler(config_entry)

--- a/custom_components/delonghi_primadonna/manifest.json
+++ b/custom_components/delonghi_primadonna/manifest.json
@@ -19,5 +19,5 @@
     "documentation": "https://github.com/Arbuzov/home_assistant_delonghi_primadonna",
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/Arbuzov/home_assistant_delonghi_primadonna/issues",
-    "version": "1.6.2"
+    "version": "1.6.3"
 }


### PR DESCRIPTION
## Summary
- allow editing device settings after setup
- support entry reload on update
- document reconfiguration in README
- bump manifest version

## Testing
- `isort --diff --check-only custom_components`
- `flake8 custom_components`

------
https://chatgpt.com/codex/tasks/task_e_685507fcce208320a9d1887abbfde705

## Summary by Sourcery

Add a configuration options flow for reconfiguring existing Delonghi Primadonna integration entries and enable automatic reload on update.

New Features:
- Add an options flow to allow editing device name, MAC address, and model after initial setup.

Enhancements:
- Automatically reload the integration entry when options are updated.

Documentation:
- Document how to access and update integration settings via the options flow in the README.

Chores:
- Bump manifest version to 1.6.3.