### PR TITLE
Handle missing raw bytes in BLE discovery

### DIFF
--- a/custom_components/delonghi_primadonna/switch.py
+++ b/custom_components/delonghi_primadonna/switch.py
@@ -31,7 +31,10 @@ async def async_setup_entry(
     ]
 
     if model and model.get("cup_light_settings", False):
-        switches.insert(0, DelongiPrimadonnaCupLightSwitch(delongh_device, hass))
+        switches.insert(
+            0,
+            DelongiPrimadonnaCupLightSwitch(delongh_device, hass),
+        )
 
     async_add_entities(switches)
     return True


### PR DESCRIPTION
## Summary
- fallback to manufacturer data when bluetooth `raw` is not available
- fix lint issues

## Testing
- `isort --diff --check-only custom_components`
- `flake8 custom_components`


------
https://chatgpt.com/codex/tasks/task_e_68556e92caec83208eb478126fdf5364

## Summary by Sourcery

Handle missing raw bytes in BLE discovery by falling back to manufacturer data and apply lint-driven formatting fixes

Enhancements:
- Fallback to manufacturer data for Bluetooth raw bytes when unavailable
- Compute and log raw hexadecimal data conditionally in discovery flow
- Reformat switch component insertion to satisfy lint requirements