### PR TITLE
Fix FutureWarning from Bleak

### DIFF
--- a/custom_components/delonghi_primadonna/device.py
+++ b/custom_components/delonghi_primadonna/device.py
@@ -276,10 +276,11 @@ class DelongiPrimadonna:
                         self._client.connect(),
                         timeout=10,
                     )
-                    await asyncio.wait_for(
-                        self._client.get_services(),
-                        timeout=10,
-                    )
+                    # Service discovery is performed during the connection
+                    # process. Accessing ``get_services`` directly raises a
+                    # ``FutureWarning`` in recent versions of Bleak.
+                    # ``self._client.services`` will contain the discovered
+                    # services once the connection succeeds.
                     await asyncio.wait_for(
                         self._client.start_notify(
                             uuid.UUID(CONTROLL_CHARACTERISTIC),


### PR DESCRIPTION
## Summary
- remove deprecated `get_services` call after connecting

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68558b6102508320aba10f030e50a259

## Summary by Sourcery

Remove the deprecated get_services call after connecting to prevent Bleak FutureWarning and rely on automatic service discovery.

Bug Fixes:
- Remove deprecated BleakClient.get_services call to avoid FutureWarning.

Enhancements:
- Add comments explaining that service discovery occurs during connection and services are available via client.services.