### PR TITLE
Add dataclasses for machine models

### DIFF
--- a/custom_components/delonghi_primadonna/image.py
+++ b/custom_components/delonghi_primadonna/image.py
@@ -7,7 +7,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DEFAULT_IMAGE_URL, DOMAIN
 from .device import DelonghiDeviceEntity, DelongiPrimadonna
-from .model import get_model
+from .model import get_machine_model
 
 
 async def async_setup_entry(
@@ -34,8 +34,6 @@ class DelongiPrimadonnaImage(DelonghiDeviceEntity, ImageEntity):
         """Initialize the image entity."""
         DelonghiDeviceEntity.__init__(self, delongh_device, hass)
         ImageEntity.__init__(self, hass)
-        model = get_model(delongh_device.product_code)
-        if model is not None:
-            url = model.get("image_url")
-            if url:
-                self._attr_image_url = url
+        model = get_machine_model(delongh_device.product_code)
+        if model is not None and model.image_url:
+            self._attr_image_url = model.image_url

--- a/custom_components/delonghi_primadonna/machine_entities.py
+++ b/custom_components/delonghi_primadonna/machine_entities.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any
+
+
+class BeverageName(StrEnum):
+    """Known beverage names from bundled machine data."""
+
+    _2X_ESPRESSO_COFFEE = "2X Espresso Coffee"
+    AMERICANO = "Americano"
+    BREW_OVER_ICE = "Brew Over Ice"
+    CAFFE_FREDDO = "Caffè freddo"
+    CAFFE_LATTE = "Caffé Latte"
+    CAPPUCCINO = "Cappuccino"
+    CAPPUCCINO_DOPPIOPLUS = "Cappuccino Doppio+"
+    CAPPUCCINO_REVERSE = "Cappuccino Reverse"
+    CIOCCO = "Ciocco"
+    COFFEE_POT = "Coffee pot"
+    COLD_MILK = "Cold Milk"
+    CORTADO = "Cortado"
+    CUSTOM = "Custom"
+    CUSTOM_01 = "Custom 01"
+    CUSTOM_02 = "Custom 02"
+    CUSTOM_03 = "Custom 03"
+    CUSTOM_04 = "Custom 04"
+    CUSTOM_05 = "Custom 05"
+    CUSTOM_06 = "Custom 06"
+    DOPPIOPLUS = "Doppio+"
+    ESPRESSO_BS_1 = "Espresso BS 1"
+    ESPRESSO_COFFEE = "Espresso Coffee"
+    ESPRESSO_MACCHIATO = "Espresso Macchiato"
+    ESPRESSO_LUNGO = "Espresso lungo"
+    FLAT_WHITE = "Flat White"
+    HOT_MILK = "Hot Milk"
+    HOT_WATER = "Hot Water"
+    ICED_AMERICANO = "Iced Americano"
+    ICED_CAFFELATTE = "Iced Caffelatte"
+    ICED_CAPPUCCINO = "Iced Cappuccino"
+    ICED_CAPPUCCINO_MIX = "Iced Cappuccino Mix"
+    ICED_COLD_MILK = "Iced Cold Milk"
+    ICED_FLAT_WHITE = "Iced Flat White"
+    ICED_LATTE_MACCHIATO = "Iced Latte Macchiato"
+    LATTE_MACCHIATO = "Latte Macchiato"
+    LONG_BLACK = "Long Black"
+    LONG_COFFEE = "Long Coffee"
+    MUG_AMERICANO = "Mug Americano"
+    MUG_CAFFELATTE = "Mug Caffelatte"
+    MUG_CAPPUCCINO = "Mug Cappuccino"
+    MUG_CAPPUCCINO_MIX = "Mug Cappuccino Mix"
+    MUG_FLAT_WHITE = "Mug Flat White"
+    MUG_HOT_MILK = "Mug Hot Milk"
+    MUG_ICED_AMERICANO = "Mug Iced Americano"
+    MUG_ICED_BREW_OVER_ICE = "Mug Iced Brew Over ice"
+    MUG_ICED_CAFFELATTE = "Mug Iced Caffelatte"
+    MUG_ICED_CAPPUCCINO = "Mug Iced Cappuccino"
+    MUG_ICED_CAPPUCCINO_MIX = "Mug Iced Cappuccino Mix"
+    MUG_ICED_COLD_MILK = "Mug Iced Cold Milk"
+    MUG_ICED_FLAT_WHITE = "Mug Iced Flat White"
+    MUG_ICED_LATTE_MACCHIATO = "Mug Iced Latte Macchiato"
+    MUG_LATTE_MACCHIATO = "Mug Latte Macchiato"
+    REGULAR_COFFEE = "Regular Coffee"
+    RISTRETTO = "Ristretto"
+    STEAM = "Steam"
+    TEA = "Tea"
+    TRAVEL_MUG = "Travel Mug"
+
+
+@dataclass(slots=True)
+class Recipe:
+    """Recipe description for a machine."""
+
+    taste: int | None = None
+    name: BeverageName | None = None
+    coffee_qty: int | None = None
+    milk_qty: int | None = None
+    min_milk: int | None = None
+    max_milk: int | None = None
+    ingredients: list[str] = field(default_factory=list)
+    min_coffee: int | None = None
+    id: str | None = None
+    max_coffee: int | None = None
+    useForCustomRecipes: bool | None = None
+
+
+@dataclass(slots=True)
+class MachineModel:
+    """Machine model description."""
+
+    profile_names_customizable: bool | None = None
+    characterSet: str | None = None
+    profile_icons_set: str | None = None
+    auto_start_settings: bool | None = None
+    globalTemperature: bool | None = None
+    filter_settings: bool | None = None
+    product_code: str | None = None
+    type: str | None = None
+    auto_off_settings: bool | None = None
+    connectionType: str | None = None
+    buzzer_settings: bool | None = None
+    multibeverage: bool | None = None
+    creationRecipes: bool | None = None
+    image_name: str | None = None
+    water_hardness_settings: bool | None = None
+    default: bool | None = None
+    cup_warmer_settings: bool | None = None
+    image2_url: str | None = None
+    protocolVersion: int | None = None
+    id: int | None = None
+    appModelId: str | None = None
+    recipes: list[Recipe] = field(default_factory=list)
+    image_url: str | None = None
+    cup_light_settings: bool | None = None
+    time_settings: bool | None = None
+    profile_icons_customizable: bool | None = None
+    nGrinders: int | None = None
+    pin_settings: bool | None = None
+    nCustomRecipes: int | None = None
+    energy_saving_settings: bool | None = None
+    protocol_minor_version: int | None = None
+    name: str | None = None
+    customizableProfiles: bool | None = None
+    nStandardRecipes: int | None = None
+    nProfiles: int | None = None
+    internationalsku: bool | None = None
+
+
+@dataclass(slots=True)
+class MachineModels:
+    """Container for all machine models."""
+
+    result: dict[str, Any] = field(default_factory=dict)
+    name: str | None = None
+    machines: list[MachineModel] = field(default_factory=list)
+    version: str | None = None

--- a/custom_components/delonghi_primadonna/switch.py
+++ b/custom_components/delonghi_primadonna/switch.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import DOMAIN
 from .device import DelonghiDeviceEntity
-from .model import get_model
+from .model import get_machine_model
 
 
 async def async_setup_entry(
@@ -22,7 +22,7 @@ async def async_setup_entry(
     """Register switch entities for a config entry."""
 
     delongh_device = hass.data[DOMAIN][entry.unique_id]
-    model = get_model(delongh_device.product_code)
+    model = get_machine_model(delongh_device.product_code)
 
     switches = [
         DelongiPrimadonnaNotificationSwitch(delongh_device, hass),
@@ -30,7 +30,7 @@ async def async_setup_entry(
         DelongiPrimadonnaSoundsSwitch(delongh_device, hass),
     ]
 
-    if model and model.get("cup_light_settings", False):
+    if model and model.cup_light_settings:
         switches.insert(
             0,
             DelongiPrimadonnaCupLightSwitch(delongh_device, hass),


### PR DESCRIPTION
## Summary
- provide dataclasses to describe machines and recipes
- load machine data into these dataclasses
- define a `BeverageName` enum for all known recipes
- parse recipe names into this enum when loading models
- change `get_model_options` to return `MachineModel` objects
- adapt config flow to convert those models into selector options
- refactor model utilities to return dataclasses

## Testing
- `isort custom_components/delonghi_primadonna/machine_entities.py custom_components/delonghi_primadonna/model.py custom_components/delonghi_primadonna/config_flow.py custom_components/delonghi_primadonna/switch.py custom_components/delonghi_primadonna/image.py`
- `flake8 custom_components`


------
https://chatgpt.com/codex/tasks/task_e_685c22b8d94c832082f3353e85ccd298

## Summary by Sourcery

Introduce structured dataclasses and an enum for machine models and recipes, migrate existing model loading and utility functions to use these types, and update the config flow, image, and switch entities accordingly.

New Features:
- Add BeverageName enum listing all known recipes
- Introduce Recipe, MachineModel, and MachineModels dataclasses to represent machine and recipe data

Enhancements:
- Replace raw JSON dicts with dataclass instances in model loading and lookup functions
- Generate selector options from MachineModel dataclasses in config flow
- Adapt image and switch entities to use dataclass attributes for image URLs and settings