### PR TITLE
Fix linter issues

### DIFF
--- a/custom_components/delonghi_primadonna/device.py
+++ b/custom_components/delonghi_primadonna/device.py
@@ -5,7 +5,7 @@ import enum
 import logging
 import uuid
 import warnings
-from binascii import hexlify, crc_hqx
+from binascii import crc_hqx, hexlify
 from enum import IntFlag
 
 from bleak import BleakClient


### PR DESCRIPTION
## Summary
- reorder `binascii` imports in `device.py`

## Testing
- `flake8 custom_components`
- `isort --check-only custom_components`


------
https://chatgpt.com/codex/tasks/task_e_686062a737d88320aa32980a9e2ecdb4

## Summary by Sourcery

Chores:
- Reorder `binascii` imports in `device.py` to fix linter (flake8/isort) issues