### PR TITLE
Add parsing of monitor switch states

### DIFF
--- a/custom_components/delonghi_primadonna/device.py
+++ b/custom_components/delonghi_primadonna/device.py
@@ -27,6 +27,7 @@ from .const import (AMERICANO_OFF, AMERICANO_ON, AVAILABLE_PROFILES,
                     ESPRESSO_ON, HOTWATER_OFF, HOTWATER_ON, LONG_OFF, LONG_ON,
                     NAME_CHARACTERISTIC, START_COFFEE, STEAM_OFF, STEAM_ON,
                     WATER_SHORTAGE, WATER_TANK_DETACHED)
+from .machine_switch import MachineSwitch, parse_switches
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -228,6 +229,7 @@ class DelongiPrimadonna:
         self.service = 0
         self.status = DEVICE_STATUS[5]
         self.switches = DeviceSwitches()
+        self.active_switches: list[MachineSwitch] = []
         self._lock = asyncio.Lock()
         self._rx_buffer = bytearray()
         self._response_event = None
@@ -412,6 +414,7 @@ class DelongiPrimadonna:
             self.steam_nozzle = NOZZLE_STATE.get(value[4], value[4])
             self.service = value[7]
             self.status = DEVICE_STATUS.get(value[5], DEVICE_STATUS[5])
+            self.active_switches = parse_switches(value)
         elif answer_id == 0xA4:
             parsed = []
             try:

--- a/custom_components/delonghi_primadonna/machine_switch.py
+++ b/custom_components/delonghi_primadonna/machine_switch.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import List
+
+
+class MachineSwitch(Enum):
+    """Known machine switches."""
+
+    WATER_SPOUT = "water_spout"
+    MOTOR_UP = "motor_up"
+    MOTOR_DOWN = "motor_down"
+    COFFEE_WASTE_CONTAINER = "coffee_waste_container"
+    WATER_TANK_ABSENT = "water_tank_absent"
+    KNOB = "knob"
+    WATER_LEVEL_LOW = "water_level_low"
+    COFFEE_JUG = "coffee_jug"
+    IFD_CARAFFE = "ifd_caraffe"
+    CIOCCO_TANK = "ciocco_tank"
+    CLEAN_KNOB = "clean_knob"
+    DOOR_OPENED = "door_opened"
+    PREGROUND_DOOR_OPENED = "preground_door_opened"
+    UNKNOWN_SWITCH = "unknown_switch"
+    IGNORE_SWITCH = "ignore_switch"
+
+
+_SWITCH_BIT_MAP: dict[int, MachineSwitch] = {
+    0: MachineSwitch.WATER_SPOUT,
+    1: MachineSwitch.IGNORE_SWITCH,
+    2: MachineSwitch.IGNORE_SWITCH,
+    3: MachineSwitch.COFFEE_WASTE_CONTAINER,
+    4: MachineSwitch.WATER_TANK_ABSENT,
+    5: MachineSwitch.KNOB,
+    6: MachineSwitch.IGNORE_SWITCH,
+    7: MachineSwitch.IGNORE_SWITCH,
+    8: MachineSwitch.IFD_CARAFFE,
+    9: MachineSwitch.CIOCCO_TANK,
+    10: MachineSwitch.CLEAN_KNOB,
+    11: MachineSwitch.IGNORE_SWITCH,
+    12: MachineSwitch.IGNORE_SWITCH,
+    13: MachineSwitch.DOOR_OPENED,
+    14: MachineSwitch.PREGROUND_DOOR_OPENED,
+}
+
+
+def switch_from_bit(index: int) -> MachineSwitch:
+    """Return machine switch for a bit index."""
+    return _SWITCH_BIT_MAP.get(index, MachineSwitch.UNKNOWN_SWITCH)
+
+
+def parse_switches(data: bytes) -> List[MachineSwitch]:
+    """Parse switch states from a monitor mode response."""
+    if len(data) < 7:
+        return []
+    mask = data[5] | (data[6] << 8)
+    result: List[MachineSwitch] = []
+    for bit in range(16):
+        if mask & (1 << bit):
+            sw = switch_from_bit(bit)
+            if sw not in (
+                MachineSwitch.IGNORE_SWITCH,
+                MachineSwitch.WATER_SPOUT,
+                MachineSwitch.IFD_CARAFFE,
+                MachineSwitch.CIOCCO_TANK,
+                MachineSwitch.UNKNOWN_SWITCH,
+            ):
+                result.append(sw)
+    return result
+
+
+__all__ = ["MachineSwitch", "parse_switches", "switch_from_bit"]


### PR DESCRIPTION
## Summary
- parse switch bitmask from monitor mode responses
- store active machine switches and expose them via new sensor

## Testing
- `isort custom_components/delonghi_primadonna/machine_switch.py custom_components/delonghi_primadonna/device.py custom_components/delonghi_primadonna/sensor.py`
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_686e386313f08320b790b8fdc6337c1a

## Summary by Sourcery

Parse monitor mode switch bitmask into enum values, track active switches in the device, and expose them through a new diagnostic sensor

New Features:
- Add a diagnostic sensor to display active machine switches

Enhancements:
- Introduce MachineSwitch enum and parse_switches function to decode switch states from the device response bitmask
- Store and restore active switch states in the device.active_switches attribute