### PR TITLE
Fix sensor state list

### DIFF
--- a/custom_components/delonghi_primadonna/machine_switch.py
+++ b/custom_components/delonghi_primadonna/machine_switch.py
@@ -34,7 +34,7 @@ _SWITCH_BIT_MAP: dict[int, MachineSwitch] = {
     6: MachineSwitch.IGNORE_SWITCH,
     7: MachineSwitch.IGNORE_SWITCH,
     8: MachineSwitch.IFD_CARAFFE,
-    9: MachineSwitch.CIOCCO_TANK,
+    9: MachineSwitch.COFFEE_WASTE_CONTAINER,
     10: MachineSwitch.CLEAN_KNOB,
     11: MachineSwitch.IGNORE_SWITCH,
     12: MachineSwitch.IGNORE_SWITCH,
@@ -52,7 +52,7 @@ def parse_switches(data: bytes) -> List[MachineSwitch]:
     """Parse switch states from a monitor mode response."""
     if len(data) < 7:
         return []
-    mask = data[5] | (data[6] << 8)
+    mask = data[5] | (data[7] << 8)
     result: List[MachineSwitch] = []
     for bit in range(16):
         if mask & (1 << bit):

--- a/custom_components/delonghi_primadonna/sensor.py
+++ b/custom_components/delonghi_primadonna/sensor.py
@@ -11,7 +11,6 @@ from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import DOMAIN
 from .device import DEVICE_STATUS, NOZZLE_STATE, DelonghiDeviceEntity
-from .machine_switch import MachineSwitch
 
 
 async def async_setup_entry(
@@ -107,12 +106,8 @@ class DelongiPrimadonnaSwitchesSensor(
 ):
     """Show active machine switches."""
 
-    _attr_device_class = SensorDeviceClass.ENUM
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_name = 'Switches'
-    _attr_options = [s.value for s in MachineSwitch if s not in (
-        MachineSwitch.IGNORE_SWITCH, MachineSwitch.UNKNOWN_SWITCH
-    )]
 
     async def async_added_to_hass(self) -> None:
         await super().async_added_to_hass()
@@ -122,7 +117,7 @@ class DelongiPrimadonnaSwitchesSensor(
     @property
     def native_value(self):
         if not self.device.active_switches:
-            return 'none'
+            return None
         return ', '.join(s.value for s in self.device.active_switches)
 
     @property


### PR DESCRIPTION
## Summary
- simplify switch sensor by removing enum options
- return `None` when there are no active switches
- parse device switches from the correct bitmask

## Testing
- `isort .`
- `flake8 .`


------
https://chatgpt.com/codex/tasks/task_e_686ea4d9bc508320aa4c9f366a88e3e5