### PR TITLE
Fix bean shortage switch parsing

### DIFF
--- a/custom_components/delonghi_primadonna/machine_switch.py
+++ b/custom_components/delonghi_primadonna/machine_switch.py
@@ -15,6 +15,7 @@ class MachineSwitch(Enum):
     KNOB = "knob"
     WATER_LEVEL_LOW = "water_level_low"
     COFFEE_JUG = "coffee_jug"
+    BEANS_EMPTY = "beans_empty"
     IFD_CARAFFE = "ifd_caraffe"
     CIOCCO_TANK = "ciocco_tank"
     CLEAN_KNOB = "clean_knob"
@@ -40,7 +41,7 @@ _SWITCH_BIT_MAP: dict[int, MachineSwitch] = {
     8: MachineSwitch.IFD_CARAFFE,
     9: MachineSwitch.COFFEE_WASTE_CONTAINER,
     10: MachineSwitch.CLEAN_KNOB,
-    11: MachineSwitch.IGNORE_SWITCH,
+    11: MachineSwitch.BEANS_EMPTY,
     12: MachineSwitch.IGNORE_SWITCH,
     13: MachineSwitch.DOOR_OPENED,
     14: MachineSwitch.PREGROUND_DOOR_OPENED,
@@ -56,7 +57,7 @@ def parse_switches(data: bytes) -> List[MachineSwitch]:
     """Parse switch states from a monitor mode response."""
     if len(data) < 7:
         return []
-    mask = data[5] | (data[7] << 8)
+    mask = data[6] | (data[7] << 8)
     result: List[MachineSwitch] = []
     for bit in range(16):
         if mask & (1 << bit):


### PR DESCRIPTION
## Summary
- add `BEANS_EMPTY` machine switch state
- map bit 11 to this new state and adjust bitmask parsing

## Testing
- `flake8 custom_components/delonghi_primadonna/machine_switch.py`
- `isort --check custom_components/delonghi_primadonna/machine_switch.py`


------
https://chatgpt.com/codex/tasks/task_e_686f9dfef39883208f5da3b075880bb8