### PR TITLE
Add translations for sensors

### DIFF
--- a/custom_components/delonghi_primadonna/device.py
+++ b/custom_components/delonghi_primadonna/device.py
@@ -58,18 +58,15 @@ class AvailableBeverage(enum.StrEnum):
 
 
 NOZZLE_STATE = {
-    -1: 'UNKNOWN',
-    0: 'DETACHED',
-    1: 'STEAM',
-    2: 'MILK_FROTHER',  # May also be Detached
-                        # It shows detached, as the water
-                        # is not flowing out
-                        # from the nozzle directly, like
-                        # the STEAM/HOT WATER nozzle does.
-    4: 'MILK_FROTHER_CLEANING',  # It shows attached,
-                                 # as the state similar to the STEAM/HOT
-                                 # WATER nozzle, water flows
-                                 # directly out the nozzle.
+    -1: "unknown",
+    0: "detached",
+    1: "steam",
+    2: "milk_frother",  # May also be Detached
+    # It shows detached, as the water is not flowing out
+    # from the nozzle directly, like the STEAM/HOT WATER nozzle does.
+    4: "milk_frother_cleaning",  # It shows attached, as the state
+    # similar to the STEAM/HOT WATER nozzle, water flows directly out
+    # the nozzle.
 }
 
 # Skipable maintanence states

--- a/custom_components/delonghi_primadonna/sensor.py
+++ b/custom_components/delonghi_primadonna/sensor.py
@@ -42,7 +42,7 @@ class DelongiPrimadonnaNozzleSensor(
 
     _attr_device_class = SensorDeviceClass.ENUM
     _attr_entity_category = EntityCategory.DIAGNOSTIC
-    _attr_name = 'Nozzle'
+    _attr_translation_key = 'nozzle_status'
 
     _attr_options = list(NOZZLE_STATE.values())
 
@@ -109,7 +109,7 @@ class DelongiPrimadonnaSwitchesSensor(
 
     _attr_device_class = SensorDeviceClass.ENUM
     _attr_entity_category = EntityCategory.DIAGNOSTIC
-    _attr_name = 'Switches'
+    _attr_translation_key = 'switches'
     _attr_options = [
         'none',
         *[s.value for s in MachineSwitch if s not in (

--- a/custom_components/delonghi_primadonna/sensor.py
+++ b/custom_components/delonghi_primadonna/sensor.py
@@ -63,9 +63,9 @@ class DelongiPrimadonnaNozzleSensor(
     @property
     def icon(self):
         result = 'mdi:coffee'
-        if self.device.steam_nozzle == 'DETACHED':
+        if self.device.steam_nozzle == "detached":
             result = 'mdi:coffee-off-outline'
-        if self.device.steam_nozzle == 'MILK':
+        if self.device.steam_nozzle.startswith("milk"):
             result = 'mdi:coffee-outline'
         return result
 

--- a/custom_components/delonghi_primadonna/strings.json
+++ b/custom_components/delonghi_primadonna/strings.json
@@ -18,30 +18,36 @@
             "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
         }
     },
-    "state": {
+    "entity": {
         "sensor": {
             "nozzle_status": {
-                "UNKNOWN": null,
-                "DETACHED": null,
-                "STEAM": null,
-                "MILK_FROTHER": null,
-                "MILK_FROTHER_CLEANING": null
+                "name": "Nozzle Status",
+                "state": {
+                    "UNKNOWN": null,
+                    "DETACHED": null,
+                    "STEAM": null,
+                    "MILK_FROTHER": null,
+                    "MILK_FROTHER_CLEANING": null
+                }
             },
             "switches": {
-                "none": null,
-                "water_spout": null,
-                "motor_up": null,
-                "motor_down": null,
-                "coffee_waste_container": null,
-                "water_tank_absent": null,
-                "knob": null,
-                "water_level_low": null,
-                "coffee_jug": null,
-                "ifd_caraffe": null,
-                "ciocco_tank": null,
-                "clean_knob": null,
-                "door_opened": null,
-                "preground_door_opened": null
+                "name": "Switches",
+                "state": {
+                    "none": null,
+                    "water_spout": null,
+                    "motor_up": null,
+                    "motor_down": null,
+                    "coffee_waste_container": null,
+                    "water_tank_absent": null,
+                    "knob": null,
+                    "water_level_low": null,
+                    "coffee_jug": null,
+                    "ifd_caraffe": null,
+                    "ciocco_tank": null,
+                    "clean_knob": null,
+                    "door_opened": null,
+                    "preground_door_opened": null
+                }
             }
         }
     }

--- a/custom_components/delonghi_primadonna/strings.json
+++ b/custom_components/delonghi_primadonna/strings.json
@@ -17,5 +17,32 @@
         "abort": {
             "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
         }
+    },
+    "state": {
+        "sensor": {
+            "nozzle_status": {
+                "UNKNOWN": null,
+                "DETACHED": null,
+                "STEAM": null,
+                "MILK_FROTHER": null,
+                "MILK_FROTHER_CLEANING": null
+            },
+            "switches": {
+                "none": null,
+                "water_spout": null,
+                "motor_up": null,
+                "motor_down": null,
+                "coffee_waste_container": null,
+                "water_tank_absent": null,
+                "knob": null,
+                "water_level_low": null,
+                "coffee_jug": null,
+                "ifd_caraffe": null,
+                "ciocco_tank": null,
+                "clean_knob": null,
+                "door_opened": null,
+                "preground_door_opened": null
+            }
+        }
     }
 }

--- a/custom_components/delonghi_primadonna/strings.json
+++ b/custom_components/delonghi_primadonna/strings.json
@@ -23,30 +23,30 @@
             "nozzle_status": {
                 "name": "Nozzle Status",
                 "state": {
-                    "UNKNOWN": null,
-                    "DETACHED": null,
-                    "STEAM": null,
-                    "MILK_FROTHER": null,
-                    "MILK_FROTHER_CLEANING": null
+                    "unknown": "Unknown",
+                    "detached": "Detached",
+                    "steam": "Steam",
+                    "milk_frother": "Milk frother",
+                    "milk_frother_cleaning": "Milk frother cleaning"
                 }
             },
             "switches": {
                 "name": "Switches",
                 "state": {
-                    "none": null,
-                    "water_spout": null,
-                    "motor_up": null,
-                    "motor_down": null,
-                    "coffee_waste_container": null,
-                    "water_tank_absent": null,
-                    "knob": null,
-                    "water_level_low": null,
-                    "coffee_jug": null,
-                    "ifd_caraffe": null,
-                    "ciocco_tank": null,
-                    "clean_knob": null,
-                    "door_opened": null,
-                    "preground_door_opened": null
+                    "none": "None",
+                    "water_spout": "Water spout",
+                    "motor_up": "Motor up",
+                    "motor_down": "Motor down",
+                    "coffee_waste_container": "Coffee waste container",
+                    "water_tank_absent": "Water tank absent",
+                    "knob": "Knob",
+                    "water_level_low": "Water level low",
+                    "coffee_jug": "Coffee jug",
+                    "ifd_caraffe": "Milk carafe",
+                    "ciocco_tank": "Chocolate tank",
+                    "clean_knob": "Clean knob",
+                    "door_opened": "Door opened",
+                    "preground_door_opened": "Preground door opened"
                 }
             }
         }

--- a/custom_components/delonghi_primadonna/translations/de.json
+++ b/custom_components/delonghi_primadonna/translations/de.json
@@ -59,11 +59,11 @@
       "nozzle_status": {
         "name": "Düsenzustand",
         "state": {
-          "UNKNOWN": "Unbekannt",
-          "DETACHED": "Abgenommen",
-          "STEAM": "Dampf",
-          "MILK_FROTHER": "Milchaufschäumer",
-          "MILK_FROTHER_CLEANING": "Milchaufschäumer (Reinigung)"
+          "unknown": "Unbekannt",
+          "detached": "Abgenommen",
+          "steam": "Dampf",
+          "milk_frother": "Milchaufschäumer",
+          "milk_frother_cleaning": "Milchaufschäumer (Reinigung)"
         }
       },
       "switches": {

--- a/custom_components/delonghi_primadonna/translations/de.json
+++ b/custom_components/delonghi_primadonna/translations/de.json
@@ -54,6 +54,14 @@
       "sounds": {
         "name": "Geräusche"
       }
+    },
+    "sensor": {
+      "nozzle_status": {
+        "name": "Düsenzustand"
+      },
+      "switches": {
+        "name": "Schalter"
+      }
     }
   },
   "services": {
@@ -84,6 +92,33 @@
         "espresso": "Espresso",
         "americano": "Americano",
         "espresso2": "Espresso 2"
+      }
+    }
+  },
+  "state": {
+    "sensor": {
+      "nozzle_status": {
+        "UNKNOWN": "Unbekannt",
+        "DETACHED": "Abgenommen",
+        "STEAM": "Dampf",
+        "MILK_FROTHER": "Milchaufschäumer",
+        "MILK_FROTHER_CLEANING": "Milchaufschäumer (Reinigung)"
+      },
+      "switches": {
+        "none": "Keine",
+        "water_spout": "Wasserauslauf",
+        "motor_up": "Motor hoch",
+        "motor_down": "Motor runter",
+        "coffee_waste_container": "Kaffeesatzbehälter",
+        "water_tank_absent": "Wassertank fehlt",
+        "knob": "Knopf",
+        "water_level_low": "Wasserstand niedrig",
+        "coffee_jug": "Kaffeekanne",
+        "ifd_caraffe": "Milchkaraffe",
+        "ciocco_tank": "Schokoladentank",
+        "clean_knob": "Reinigungsknopf",
+        "door_opened": "Tür geöffnet",
+        "preground_door_opened": "Fach für gemahlenen Kaffee geöffnet"
       }
     }
   }

--- a/custom_components/delonghi_primadonna/translations/de.json
+++ b/custom_components/delonghi_primadonna/translations/de.json
@@ -57,10 +57,33 @@
     },
     "sensor": {
       "nozzle_status": {
-        "name": "Düsenzustand"
+        "name": "Düsenzustand",
+        "state": {
+          "UNKNOWN": "Unbekannt",
+          "DETACHED": "Abgenommen",
+          "STEAM": "Dampf",
+          "MILK_FROTHER": "Milchaufschäumer",
+          "MILK_FROTHER_CLEANING": "Milchaufschäumer (Reinigung)"
+        }
       },
       "switches": {
-        "name": "Schalter"
+        "name": "Schalter",
+        "state": {
+          "none": "Keine",
+          "water_spout": "Wasserauslauf",
+          "motor_up": "Motor hoch",
+          "motor_down": "Motor runter",
+          "coffee_waste_container": "Kaffeesatzbehälter",
+          "water_tank_absent": "Wassertank fehlt",
+          "knob": "Knopf",
+          "water_level_low": "Wasserstand niedrig",
+          "coffee_jug": "Kaffeekanne",
+          "ifd_caraffe": "Milchkaraffe",
+          "ciocco_tank": "Schokoladentank",
+          "clean_knob": "Reinigungsknopf",
+          "door_opened": "Tür geöffnet",
+          "preground_door_opened": "Fach für gemahlenen Kaffee geöffnet"
+        }
       }
     }
   },
@@ -92,33 +115,6 @@
         "espresso": "Espresso",
         "americano": "Americano",
         "espresso2": "Espresso 2"
-      }
-    }
-  },
-  "state": {
-    "sensor": {
-      "nozzle_status": {
-        "UNKNOWN": "Unbekannt",
-        "DETACHED": "Abgenommen",
-        "STEAM": "Dampf",
-        "MILK_FROTHER": "Milchaufschäumer",
-        "MILK_FROTHER_CLEANING": "Milchaufschäumer (Reinigung)"
-      },
-      "switches": {
-        "none": "Keine",
-        "water_spout": "Wasserauslauf",
-        "motor_up": "Motor hoch",
-        "motor_down": "Motor runter",
-        "coffee_waste_container": "Kaffeesatzbehälter",
-        "water_tank_absent": "Wassertank fehlt",
-        "knob": "Knopf",
-        "water_level_low": "Wasserstand niedrig",
-        "coffee_jug": "Kaffeekanne",
-        "ifd_caraffe": "Milchkaraffe",
-        "ciocco_tank": "Schokoladentank",
-        "clean_knob": "Reinigungsknopf",
-        "door_opened": "Tür geöffnet",
-        "preground_door_opened": "Fach für gemahlenen Kaffee geöffnet"
       }
     }
   }

--- a/custom_components/delonghi_primadonna/translations/en.json
+++ b/custom_components/delonghi_primadonna/translations/en.json
@@ -57,37 +57,33 @@
     },
     "sensor": {
       "nozzle_status": {
-        "name": "Nozzle Status"
+        "name": "Nozzle Status",
+        "state": {
+          "UNKNOWN": "Unknown",
+          "DETACHED": "Detached",
+          "STEAM": "Steam",
+          "MILK_FROTHER": "Milk frother",
+          "MILK_FROTHER_CLEANING": "Milk frother cleaning"
+        }
       },
       "switches": {
-        "name": "Switches"
-      }
-    }
-  },
-  "state": {
-    "sensor": {
-      "nozzle_status": {
-        "UNKNOWN": "Unknown",
-        "DETACHED": "Detached",
-        "STEAM": "Steam",
-        "MILK_FROTHER": "Milk frother",
-        "MILK_FROTHER_CLEANING": "Milk frother cleaning"
-      },
-      "switches": {
-        "none": "None",
-        "water_spout": "Water spout",
-        "motor_up": "Motor up",
-        "motor_down": "Motor down",
-        "coffee_waste_container": "Coffee waste container",
-        "water_tank_absent": "Water tank absent",
-        "knob": "Knob",
-        "water_level_low": "Water level low",
-        "coffee_jug": "Coffee jug",
-        "ifd_caraffe": "Milk carafe",
-        "ciocco_tank": "Chocolate tank",
-        "clean_knob": "Clean knob",
-        "door_opened": "Door opened",
-        "preground_door_opened": "Preground door opened"
+        "name": "Switches",
+        "state": {
+          "none": "None",
+          "water_spout": "Water spout",
+          "motor_up": "Motor up",
+          "motor_down": "Motor down",
+          "coffee_waste_container": "Coffee waste container",
+          "water_tank_absent": "Water tank absent",
+          "knob": "Knob",
+          "water_level_low": "Water level low",
+          "coffee_jug": "Coffee jug",
+          "ifd_caraffe": "Milk carafe",
+          "ciocco_tank": "Chocolate tank",
+          "clean_knob": "Clean knob",
+          "door_opened": "Door opened",
+          "preground_door_opened": "Preground door opened"
+        }
       }
     }
   },

--- a/custom_components/delonghi_primadonna/translations/en.json
+++ b/custom_components/delonghi_primadonna/translations/en.json
@@ -59,11 +59,11 @@
       "nozzle_status": {
         "name": "Nozzle Status",
         "state": {
-          "UNKNOWN": "Unknown",
-          "DETACHED": "Detached",
-          "STEAM": "Steam",
-          "MILK_FROTHER": "Milk frother",
-          "MILK_FROTHER_CLEANING": "Milk frother cleaning"
+          "unknown": "Unknown",
+          "detached": "Detached",
+          "steam": "Steam",
+          "milk_frother": "Milk frother",
+          "milk_frother_cleaning": "Milk frother cleaning"
         }
       },
       "switches": {

--- a/custom_components/delonghi_primadonna/translations/en.json
+++ b/custom_components/delonghi_primadonna/translations/en.json
@@ -54,6 +54,41 @@
       "sounds": {
         "name": "Sounds"
       }
+    },
+    "sensor": {
+      "nozzle_status": {
+        "name": "Nozzle Status"
+      },
+      "switches": {
+        "name": "Switches"
+      }
+    }
+  },
+  "state": {
+    "sensor": {
+      "nozzle_status": {
+        "UNKNOWN": "Unknown",
+        "DETACHED": "Detached",
+        "STEAM": "Steam",
+        "MILK_FROTHER": "Milk frother",
+        "MILK_FROTHER_CLEANING": "Milk frother cleaning"
+      },
+      "switches": {
+        "none": "None",
+        "water_spout": "Water spout",
+        "motor_up": "Motor up",
+        "motor_down": "Motor down",
+        "coffee_waste_container": "Coffee waste container",
+        "water_tank_absent": "Water tank absent",
+        "knob": "Knob",
+        "water_level_low": "Water level low",
+        "coffee_jug": "Coffee jug",
+        "ifd_caraffe": "Milk carafe",
+        "ciocco_tank": "Chocolate tank",
+        "clean_knob": "Clean knob",
+        "door_opened": "Door opened",
+        "preground_door_opened": "Preground door opened"
+      }
     }
   },
   "services": {

--- a/custom_components/delonghi_primadonna/translations/fr.json
+++ b/custom_components/delonghi_primadonna/translations/fr.json
@@ -57,10 +57,33 @@
     },
     "sensor": {
       "nozzle_status": {
-        "name": "État de la buse"
+        "name": "État de la buse",
+        "state": {
+          "UNKNOWN": "Inconnu",
+          "DETACHED": "Détachée",
+          "STEAM": "Vapeur",
+          "MILK_FROTHER": "Mousseur à lait",
+          "MILK_FROTHER_CLEANING": "Mousseur à lait (nettoyage)"
+        }
       },
       "switches": {
-        "name": "Interrupteurs"
+        "name": "Interrupteurs",
+        "state": {
+          "none": "Aucun",
+          "water_spout": "Sortie d'eau",
+          "motor_up": "Moteur vers le haut",
+          "motor_down": "Moteur vers le bas",
+          "coffee_waste_container": "Bac à marc de café",
+          "water_tank_absent": "Réservoir d'eau absent",
+          "knob": "Bouton",
+          "water_level_low": "Niveau d'eau bas",
+          "coffee_jug": "Carafe à café",
+          "ifd_caraffe": "Carafe à lait",
+          "ciocco_tank": "Réservoir de chocolat",
+          "clean_knob": "Bouton de nettoyage",
+          "door_opened": "Porte ouverte",
+          "preground_door_opened": "Trappe à café moulu ouverte"
+        }
       }
     }
   },
@@ -92,33 +115,6 @@
         "espresso": "Espresso",
         "americano": "Américain",
         "espresso2": "Expresso 2"
-      }
-    }
-  },
-  "state": {
-    "sensor": {
-      "nozzle_status": {
-        "UNKNOWN": "Inconnu",
-        "DETACHED": "Détachée",
-        "STEAM": "Vapeur",
-        "MILK_FROTHER": "Mousseur à lait",
-        "MILK_FROTHER_CLEANING": "Mousseur à lait (nettoyage)"
-      },
-      "switches": {
-        "none": "Aucun",
-        "water_spout": "Sortie d'eau",
-        "motor_up": "Moteur vers le haut",
-        "motor_down": "Moteur vers le bas",
-        "coffee_waste_container": "Bac à marc de café",
-        "water_tank_absent": "Réservoir d'eau absent",
-        "knob": "Bouton",
-        "water_level_low": "Niveau d'eau bas",
-        "coffee_jug": "Carafe à café",
-        "ifd_caraffe": "Carafe à lait",
-        "ciocco_tank": "Réservoir de chocolat",
-        "clean_knob": "Bouton de nettoyage",
-        "door_opened": "Porte ouverte",
-        "preground_door_opened": "Trappe à café moulu ouverte"
       }
     }
   }

--- a/custom_components/delonghi_primadonna/translations/fr.json
+++ b/custom_components/delonghi_primadonna/translations/fr.json
@@ -54,6 +54,14 @@
       "sounds": {
         "name": "Sons"
       }
+    },
+    "sensor": {
+      "nozzle_status": {
+        "name": "État de la buse"
+      },
+      "switches": {
+        "name": "Interrupteurs"
+      }
     }
   },
   "services": {
@@ -84,6 +92,33 @@
         "espresso": "Espresso",
         "americano": "Américain",
         "espresso2": "Expresso 2"
+      }
+    }
+  },
+  "state": {
+    "sensor": {
+      "nozzle_status": {
+        "UNKNOWN": "Inconnu",
+        "DETACHED": "Détachée",
+        "STEAM": "Vapeur",
+        "MILK_FROTHER": "Mousseur à lait",
+        "MILK_FROTHER_CLEANING": "Mousseur à lait (nettoyage)"
+      },
+      "switches": {
+        "none": "Aucun",
+        "water_spout": "Sortie d'eau",
+        "motor_up": "Moteur vers le haut",
+        "motor_down": "Moteur vers le bas",
+        "coffee_waste_container": "Bac à marc de café",
+        "water_tank_absent": "Réservoir d'eau absent",
+        "knob": "Bouton",
+        "water_level_low": "Niveau d'eau bas",
+        "coffee_jug": "Carafe à café",
+        "ifd_caraffe": "Carafe à lait",
+        "ciocco_tank": "Réservoir de chocolat",
+        "clean_knob": "Bouton de nettoyage",
+        "door_opened": "Porte ouverte",
+        "preground_door_opened": "Trappe à café moulu ouverte"
       }
     }
   }

--- a/custom_components/delonghi_primadonna/translations/fr.json
+++ b/custom_components/delonghi_primadonna/translations/fr.json
@@ -59,11 +59,11 @@
       "nozzle_status": {
         "name": "État de la buse",
         "state": {
-          "UNKNOWN": "Inconnu",
-          "DETACHED": "Détachée",
-          "STEAM": "Vapeur",
-          "MILK_FROTHER": "Mousseur à lait",
-          "MILK_FROTHER_CLEANING": "Mousseur à lait (nettoyage)"
+          "unknown": "Inconnu",
+          "detached": "Détachée",
+          "steam": "Vapeur",
+          "milk_frother": "Mousseur à lait",
+          "milk_frother_cleaning": "Mousseur à lait (nettoyage)"
         }
       },
       "switches": {

--- a/custom_components/delonghi_primadonna/translations/hu.json
+++ b/custom_components/delonghi_primadonna/translations/hu.json
@@ -57,10 +57,33 @@
     },
     "sensor": {
       "nozzle_status": {
-        "name": "Fúvóka állapota"
+        "name": "Fúvóka állapota",
+        "state": {
+          "UNKNOWN": "Ismeretlen",
+          "DETACHED": "Leválasztva",
+          "STEAM": "Gőz",
+          "MILK_FROTHER": "Tejhabosító",
+          "MILK_FROTHER_CLEANING": "Tejhabosító (tisztítás)"
+        }
       },
       "switches": {
-        "name": "Kapcsolók"
+        "name": "Kapcsolók",
+        "state": {
+          "none": "Nincs",
+          "water_spout": "Vízkifolyó",
+          "motor_up": "Motor fel",
+          "motor_down": "Motor le",
+          "coffee_waste_container": "Kávézacc tartály",
+          "water_tank_absent": "Víztartály hiányzik",
+          "knob": "Gomb",
+          "water_level_low": "Alacsony vízszint",
+          "coffee_jug": "Kávés kancsó",
+          "ifd_caraffe": "Tejes kancsó",
+          "ciocco_tank": "Csokoládétartály",
+          "clean_knob": "Tisztító gomb",
+          "door_opened": "Ajtó nyitva",
+          "preground_door_opened": "Őrölt kávé nyílás nyitva"
+        }
       }
     }
   },
@@ -92,33 +115,6 @@
         "espresso": "Eszpresszó",
         "americano": "Amerikai",
         "espresso2": "Espresso 2"
-      }
-    }
-  },
-  "state": {
-    "sensor": {
-      "nozzle_status": {
-        "UNKNOWN": "Ismeretlen",
-        "DETACHED": "Leválasztva",
-        "STEAM": "Gőz",
-        "MILK_FROTHER": "Tejhabosító",
-        "MILK_FROTHER_CLEANING": "Tejhabosító (tisztítás)"
-      },
-      "switches": {
-        "none": "Nincs",
-        "water_spout": "Vízkifolyó",
-        "motor_up": "Motor fel",
-        "motor_down": "Motor le",
-        "coffee_waste_container": "Kávézacc tartály",
-        "water_tank_absent": "Víztartály hiányzik",
-        "knob": "Gomb",
-        "water_level_low": "Alacsony vízszint",
-        "coffee_jug": "Kávés kancsó",
-        "ifd_caraffe": "Tejes kancsó",
-        "ciocco_tank": "Csokoládétartály",
-        "clean_knob": "Tisztító gomb",
-        "door_opened": "Ajtó nyitva",
-        "preground_door_opened": "Őrölt kávé nyílás nyitva"
       }
     }
   }

--- a/custom_components/delonghi_primadonna/translations/hu.json
+++ b/custom_components/delonghi_primadonna/translations/hu.json
@@ -54,6 +54,14 @@
       "sounds": {
         "name": "Hangok"
       }
+    },
+    "sensor": {
+      "nozzle_status": {
+        "name": "Fúvóka állapota"
+      },
+      "switches": {
+        "name": "Kapcsolók"
+      }
     }
   },
   "services": {
@@ -84,6 +92,33 @@
         "espresso": "Eszpresszó",
         "americano": "Amerikai",
         "espresso2": "Espresso 2"
+      }
+    }
+  },
+  "state": {
+    "sensor": {
+      "nozzle_status": {
+        "UNKNOWN": "Ismeretlen",
+        "DETACHED": "Leválasztva",
+        "STEAM": "Gőz",
+        "MILK_FROTHER": "Tejhabosító",
+        "MILK_FROTHER_CLEANING": "Tejhabosító (tisztítás)"
+      },
+      "switches": {
+        "none": "Nincs",
+        "water_spout": "Vízkifolyó",
+        "motor_up": "Motor fel",
+        "motor_down": "Motor le",
+        "coffee_waste_container": "Kávézacc tartály",
+        "water_tank_absent": "Víztartály hiányzik",
+        "knob": "Gomb",
+        "water_level_low": "Alacsony vízszint",
+        "coffee_jug": "Kávés kancsó",
+        "ifd_caraffe": "Tejes kancsó",
+        "ciocco_tank": "Csokoládétartály",
+        "clean_knob": "Tisztító gomb",
+        "door_opened": "Ajtó nyitva",
+        "preground_door_opened": "Őrölt kávé nyílás nyitva"
       }
     }
   }

--- a/custom_components/delonghi_primadonna/translations/hu.json
+++ b/custom_components/delonghi_primadonna/translations/hu.json
@@ -59,11 +59,11 @@
       "nozzle_status": {
         "name": "Fúvóka állapota",
         "state": {
-          "UNKNOWN": "Ismeretlen",
-          "DETACHED": "Leválasztva",
-          "STEAM": "Gőz",
-          "MILK_FROTHER": "Tejhabosító",
-          "MILK_FROTHER_CLEANING": "Tejhabosító (tisztítás)"
+          "unknown": "Ismeretlen",
+          "detached": "Leválasztva",
+          "steam": "Gőz",
+          "milk_frother": "Tejhabosító",
+          "milk_frother_cleaning": "Tejhabosító (tisztítás)"
         }
       },
       "switches": {

--- a/custom_components/delonghi_primadonna/translations/it.json
+++ b/custom_components/delonghi_primadonna/translations/it.json
@@ -54,6 +54,14 @@
       "sounds": {
         "name": "Suoni"
       }
+    },
+    "sensor": {
+      "nozzle_status": {
+        "name": "Stato dell'ugello"
+      },
+      "switches": {
+        "name": "Interruttori"
+      }
     }
   },
   "services": {
@@ -84,6 +92,33 @@
         "espresso": "Espresso",
         "americano": "Americano",
         "espresso2": "Espresso 2"
+      }
+    }
+  },
+  "state": {
+    "sensor": {
+      "nozzle_status": {
+        "UNKNOWN": "Sconosciuto",
+        "DETACHED": "Rimosso",
+        "STEAM": "Vapore",
+        "MILK_FROTHER": "Montalatte",
+        "MILK_FROTHER_CLEANING": "Montalatte (pulizia)"
+      },
+      "switches": {
+        "none": "Nessuno",
+        "water_spout": "Erogatore d'acqua",
+        "motor_up": "Motore su",
+        "motor_down": "Motore giù",
+        "coffee_waste_container": "Contenitore fondi caffè",
+        "water_tank_absent": "Serbatoio acqua assente",
+        "knob": "Manopola",
+        "water_level_low": "Livello acqua basso",
+        "coffee_jug": "Caraffa del caffè",
+        "ifd_caraffe": "Caraffa del latte",
+        "ciocco_tank": "Serbatoio cioccolata",
+        "clean_knob": "Manopola pulizia",
+        "door_opened": "Sportello aperto",
+        "preground_door_opened": "Sportello caffè macinato aperto"
       }
     }
   }

--- a/custom_components/delonghi_primadonna/translations/it.json
+++ b/custom_components/delonghi_primadonna/translations/it.json
@@ -59,11 +59,11 @@
       "nozzle_status": {
         "name": "Stato dell'ugello",
         "state": {
-          "UNKNOWN": "Sconosciuto",
-          "DETACHED": "Rimosso",
-          "STEAM": "Vapore",
-          "MILK_FROTHER": "Montalatte",
-          "MILK_FROTHER_CLEANING": "Montalatte (pulizia)"
+          "unknown": "Sconosciuto",
+          "detached": "Rimosso",
+          "steam": "Vapore",
+          "milk_frother": "Montalatte",
+          "milk_frother_cleaning": "Montalatte (pulizia)"
         }
       },
       "switches": {

--- a/custom_components/delonghi_primadonna/translations/it.json
+++ b/custom_components/delonghi_primadonna/translations/it.json
@@ -57,10 +57,33 @@
     },
     "sensor": {
       "nozzle_status": {
-        "name": "Stato dell'ugello"
+        "name": "Stato dell'ugello",
+        "state": {
+          "UNKNOWN": "Sconosciuto",
+          "DETACHED": "Rimosso",
+          "STEAM": "Vapore",
+          "MILK_FROTHER": "Montalatte",
+          "MILK_FROTHER_CLEANING": "Montalatte (pulizia)"
+        }
       },
       "switches": {
-        "name": "Interruttori"
+        "name": "Interruttori",
+        "state": {
+          "none": "Nessuno",
+          "water_spout": "Erogatore d'acqua",
+          "motor_up": "Motore su",
+          "motor_down": "Motore giù",
+          "coffee_waste_container": "Contenitore fondi caffè",
+          "water_tank_absent": "Serbatoio acqua assente",
+          "knob": "Manopola",
+          "water_level_low": "Livello acqua basso",
+          "coffee_jug": "Caraffa del caffè",
+          "ifd_caraffe": "Caraffa del latte",
+          "ciocco_tank": "Serbatoio cioccolata",
+          "clean_knob": "Manopola pulizia",
+          "door_opened": "Sportello aperto",
+          "preground_door_opened": "Sportello caffè macinato aperto"
+        }
       }
     }
   },
@@ -92,33 +115,6 @@
         "espresso": "Espresso",
         "americano": "Americano",
         "espresso2": "Espresso 2"
-      }
-    }
-  },
-  "state": {
-    "sensor": {
-      "nozzle_status": {
-        "UNKNOWN": "Sconosciuto",
-        "DETACHED": "Rimosso",
-        "STEAM": "Vapore",
-        "MILK_FROTHER": "Montalatte",
-        "MILK_FROTHER_CLEANING": "Montalatte (pulizia)"
-      },
-      "switches": {
-        "none": "Nessuno",
-        "water_spout": "Erogatore d'acqua",
-        "motor_up": "Motore su",
-        "motor_down": "Motore giù",
-        "coffee_waste_container": "Contenitore fondi caffè",
-        "water_tank_absent": "Serbatoio acqua assente",
-        "knob": "Manopola",
-        "water_level_low": "Livello acqua basso",
-        "coffee_jug": "Caraffa del caffè",
-        "ifd_caraffe": "Caraffa del latte",
-        "ciocco_tank": "Serbatoio cioccolata",
-        "clean_knob": "Manopola pulizia",
-        "door_opened": "Sportello aperto",
-        "preground_door_opened": "Sportello caffè macinato aperto"
       }
     }
   }

--- a/custom_components/delonghi_primadonna/translations/ja.json
+++ b/custom_components/delonghi_primadonna/translations/ja.json
@@ -57,10 +57,33 @@
     },
     "sensor": {
       "nozzle_status": {
-        "name": "ノズル状態"
+        "name": "ノズル状態",
+        "state": {
+          "UNKNOWN": "不明",
+          "DETACHED": "取り外し",
+          "STEAM": "スチーム",
+          "MILK_FROTHER": "ミルクフロッサー",
+          "MILK_FROTHER_CLEANING": "ミルクフロッサー（清掃）"
+        }
       },
       "switches": {
-        "name": "スイッチ"
+        "name": "スイッチ",
+        "state": {
+          "none": "なし",
+          "water_spout": "緊水口",
+          "motor_up": "モーター上",
+          "motor_down": "モーター下",
+          "coffee_waste_container": "コーヒーカス容器",
+          "water_tank_absent": "水タンクなし",
+          "knob": "ノブ",
+          "water_level_low": "水位低下",
+          "coffee_jug": "コーヒージャグ",
+          "ifd_caraffe": "ミルクカラフェ",
+          "ciocco_tank": "チョコレートタンク",
+          "clean_knob": "清掃ノブ",
+          "door_opened": "ドア開",
+          "preground_door_opened": "粉入れ口開"
+        }
       }
     }
   },
@@ -92,33 +115,6 @@
         "espresso": "エスプレッソ",
         "americano": "アメリカーノ",
         "espresso2": "エスプレッソ2"
-      }
-    }
-  },
-  "state": {
-    "sensor": {
-      "nozzle_status": {
-        "UNKNOWN": "不明",
-        "DETACHED": "取り外し",
-        "STEAM": "スチーム",
-        "MILK_FROTHER": "ミルクフロッサー",
-        "MILK_FROTHER_CLEANING": "ミルクフロッサー（清掃）"
-      },
-      "switches": {
-        "none": "なし",
-        "water_spout": "緊水口",
-        "motor_up": "モーター上",
-        "motor_down": "モーター下",
-        "coffee_waste_container": "コーヒーカス容器",
-        "water_tank_absent": "水タンクなし",
-        "knob": "ノブ",
-        "water_level_low": "水位低下",
-        "coffee_jug": "コーヒージャグ",
-        "ifd_caraffe": "ミルクカラフェ",
-        "ciocco_tank": "チョコレートタンク",
-        "clean_knob": "清掃ノブ",
-        "door_opened": "ドア開",
-        "preground_door_opened": "粉入れ口開"
       }
     }
   }

--- a/custom_components/delonghi_primadonna/translations/ja.json
+++ b/custom_components/delonghi_primadonna/translations/ja.json
@@ -54,6 +54,14 @@
       "sounds": {
         "name": "音"
       }
+    },
+    "sensor": {
+      "nozzle_status": {
+        "name": "ノズル状態"
+      },
+      "switches": {
+        "name": "スイッチ"
+      }
     }
   },
   "services": {
@@ -84,6 +92,33 @@
         "espresso": "エスプレッソ",
         "americano": "アメリカーノ",
         "espresso2": "エスプレッソ2"
+      }
+    }
+  },
+  "state": {
+    "sensor": {
+      "nozzle_status": {
+        "UNKNOWN": "不明",
+        "DETACHED": "取り外し",
+        "STEAM": "スチーム",
+        "MILK_FROTHER": "ミルクフロッサー",
+        "MILK_FROTHER_CLEANING": "ミルクフロッサー（清掃）"
+      },
+      "switches": {
+        "none": "なし",
+        "water_spout": "緊水口",
+        "motor_up": "モーター上",
+        "motor_down": "モーター下",
+        "coffee_waste_container": "コーヒーカス容器",
+        "water_tank_absent": "水タンクなし",
+        "knob": "ノブ",
+        "water_level_low": "水位低下",
+        "coffee_jug": "コーヒージャグ",
+        "ifd_caraffe": "ミルクカラフェ",
+        "ciocco_tank": "チョコレートタンク",
+        "clean_knob": "清掃ノブ",
+        "door_opened": "ドア開",
+        "preground_door_opened": "粉入れ口開"
       }
     }
   }

--- a/custom_components/delonghi_primadonna/translations/ja.json
+++ b/custom_components/delonghi_primadonna/translations/ja.json
@@ -59,11 +59,11 @@
       "nozzle_status": {
         "name": "ノズル状態",
         "state": {
-          "UNKNOWN": "不明",
-          "DETACHED": "取り外し",
-          "STEAM": "スチーム",
-          "MILK_FROTHER": "ミルクフロッサー",
-          "MILK_FROTHER_CLEANING": "ミルクフロッサー（清掃）"
+          "unknown": "不明",
+          "detached": "取り外し",
+          "steam": "スチーム",
+          "milk_frother": "ミルクフロッサー",
+          "milk_frother_cleaning": "ミルクフロッサー（清掃）"
         }
       },
       "switches": {

--- a/custom_components/delonghi_primadonna/translations/ko.json
+++ b/custom_components/delonghi_primadonna/translations/ko.json
@@ -59,11 +59,11 @@
       "nozzle_status": {
         "name": "노즈 상태",
         "state": {
-          "UNKNOWN": "알 수 없음",
-          "DETACHED": "분리됨",
-          "STEAM": "스티림",
-          "MILK_FROTHER": "우육 푸름기",
-          "MILK_FROTHER_CLEANING": "우육 푸름기 세청"
+          "unknown": "알 수 없음",
+          "detached": "분리됨",
+          "steam": "스티림",
+          "milk_frother": "우육 푸름기",
+          "milk_frother_cleaning": "우육 푸름기 세청"
         }
       },
       "switches": {

--- a/custom_components/delonghi_primadonna/translations/ko.json
+++ b/custom_components/delonghi_primadonna/translations/ko.json
@@ -57,10 +57,33 @@
     },
     "sensor": {
       "nozzle_status": {
-        "name": "노즈 상태"
+        "name": "노즈 상태",
+        "state": {
+          "UNKNOWN": "알 수 없음",
+          "DETACHED": "분리됨",
+          "STEAM": "스티림",
+          "MILK_FROTHER": "우육 푸름기",
+          "MILK_FROTHER_CLEANING": "우육 푸름기 세청"
+        }
       },
       "switches": {
-        "name": "스위치"
+        "name": "스위치",
+        "state": {
+          "none": "없음",
+          "water_spout": "물 남기",
+          "motor_up": "모터 위",
+          "motor_down": "모터 아래",
+          "coffee_waste_container": "커피 지금 통",
+          "water_tank_absent": "물탱크 없음",
+          "knob": "노브",
+          "water_level_low": "물 레벨 낮음",
+          "coffee_jug": "커피 주자",
+          "ifd_caraffe": "우육 카라페",
+          "ciocco_tank": "초콜레이트 탱크",
+          "clean_knob": "초경 노브",
+          "door_opened": "문 열랄",
+          "preground_door_opened": "가르다 커피 문 열랄"
+        }
       }
     }
   },
@@ -92,33 +115,6 @@
         "espresso": "에스프레소 커피",
         "americano": "아메리카노",
         "espresso2": "에스프레소 2"
-      }
-    }
-  },
-  "state": {
-    "sensor": {
-      "nozzle_status": {
-        "UNKNOWN": "알 수 없음",
-        "DETACHED": "분리됨",
-        "STEAM": "스티림",
-        "MILK_FROTHER": "우육 푸름기",
-        "MILK_FROTHER_CLEANING": "우육 푸름기 세청"
-      },
-      "switches": {
-        "none": "없음",
-        "water_spout": "물 남기",
-        "motor_up": "모터 위",
-        "motor_down": "모터 아래",
-        "coffee_waste_container": "커피 지금 통",
-        "water_tank_absent": "물탱크 없음",
-        "knob": "노브",
-        "water_level_low": "물 레벨 낮음",
-        "coffee_jug": "커피 주자",
-        "ifd_caraffe": "우육 카라페",
-        "ciocco_tank": "초콜레이트 탱크",
-        "clean_knob": "초경 노브",
-        "door_opened": "문 열랄",
-        "preground_door_opened": "가르다 커피 문 열랄"
       }
     }
   }

--- a/custom_components/delonghi_primadonna/translations/ko.json
+++ b/custom_components/delonghi_primadonna/translations/ko.json
@@ -54,6 +54,14 @@
       "sounds": {
         "name": "소리"
       }
+    },
+    "sensor": {
+      "nozzle_status": {
+        "name": "노즈 상태"
+      },
+      "switches": {
+        "name": "스위치"
+      }
     }
   },
   "services": {
@@ -84,6 +92,33 @@
         "espresso": "에스프레소 커피",
         "americano": "아메리카노",
         "espresso2": "에스프레소 2"
+      }
+    }
+  },
+  "state": {
+    "sensor": {
+      "nozzle_status": {
+        "UNKNOWN": "알 수 없음",
+        "DETACHED": "분리됨",
+        "STEAM": "스티림",
+        "MILK_FROTHER": "우육 푸름기",
+        "MILK_FROTHER_CLEANING": "우육 푸름기 세청"
+      },
+      "switches": {
+        "none": "없음",
+        "water_spout": "물 남기",
+        "motor_up": "모터 위",
+        "motor_down": "모터 아래",
+        "coffee_waste_container": "커피 지금 통",
+        "water_tank_absent": "물탱크 없음",
+        "knob": "노브",
+        "water_level_low": "물 레벨 낮음",
+        "coffee_jug": "커피 주자",
+        "ifd_caraffe": "우육 카라페",
+        "ciocco_tank": "초콜레이트 탱크",
+        "clean_knob": "초경 노브",
+        "door_opened": "문 열랄",
+        "preground_door_opened": "가르다 커피 문 열랄"
       }
     }
   }

--- a/custom_components/delonghi_primadonna/translations/pl.json
+++ b/custom_components/delonghi_primadonna/translations/pl.json
@@ -57,10 +57,33 @@
     },
     "sensor": {
       "nozzle_status": {
-        "name": "Stan dyszy"
+        "name": "Stan dyszy",
+        "state": {
+          "UNKNOWN": "Nieznany",
+          "DETACHED": "Odłączona",
+          "STEAM": "Para",
+          "MILK_FROTHER": "Spieniacz mleka",
+          "MILK_FROTHER_CLEANING": "Spieniacz mleka (czyszczenie)"
+        }
       },
       "switches": {
-        "name": "Przełączniki"
+        "name": "Przełączniki",
+        "state": {
+          "none": "Brak",
+          "water_spout": "Wylewka wodna",
+          "motor_up": "Silnik w górę",
+          "motor_down": "Silnik w dół",
+          "coffee_waste_container": "Pojemnik na fusy",
+          "water_tank_absent": "Brak zbiornika wody",
+          "knob": "Pokrętło",
+          "water_level_low": "Niski poziom wody",
+          "coffee_jug": "Dzbanek do kawy",
+          "ifd_caraffe": "Dzbanek na mleko",
+          "ciocco_tank": "Zbiornik czekolady",
+          "clean_knob": "Pokrętło czyszczenia",
+          "door_opened": "Drzwi otwarte",
+          "preground_door_opened": "Otwarta klapka mielonej kawy"
+        }
       }
     }
   },
@@ -92,33 +115,6 @@
         "espresso": "Espresso",
         "americano": "Americano",
         "espresso2": "Podwójne Espresso"
-      }
-    }
-  },
-  "state": {
-    "sensor": {
-      "nozzle_status": {
-        "UNKNOWN": "Nieznany",
-        "DETACHED": "Odłączona",
-        "STEAM": "Para",
-        "MILK_FROTHER": "Spieniacz mleka",
-        "MILK_FROTHER_CLEANING": "Spieniacz mleka (czyszczenie)"
-      },
-      "switches": {
-        "none": "Brak",
-        "water_spout": "Wylewka wodna",
-        "motor_up": "Silnik w górę",
-        "motor_down": "Silnik w dół",
-        "coffee_waste_container": "Pojemnik na fusy",
-        "water_tank_absent": "Brak zbiornika wody",
-        "knob": "Pokrętło",
-        "water_level_low": "Niski poziom wody",
-        "coffee_jug": "Dzbanek do kawy",
-        "ifd_caraffe": "Dzbanek na mleko",
-        "ciocco_tank": "Zbiornik czekolady",
-        "clean_knob": "Pokrętło czyszczenia",
-        "door_opened": "Drzwi otwarte",
-        "preground_door_opened": "Otwarta klapka mielonej kawy"
       }
     }
   }

--- a/custom_components/delonghi_primadonna/translations/pl.json
+++ b/custom_components/delonghi_primadonna/translations/pl.json
@@ -54,6 +54,14 @@
       "sounds": {
         "name": "Dźwięk"
       }
+    },
+    "sensor": {
+      "nozzle_status": {
+        "name": "Stan dyszy"
+      },
+      "switches": {
+        "name": "Przełączniki"
+      }
     }
   },
   "services": {
@@ -84,6 +92,33 @@
         "espresso": "Espresso",
         "americano": "Americano",
         "espresso2": "Podwójne Espresso"
+      }
+    }
+  },
+  "state": {
+    "sensor": {
+      "nozzle_status": {
+        "UNKNOWN": "Nieznany",
+        "DETACHED": "Odłączona",
+        "STEAM": "Para",
+        "MILK_FROTHER": "Spieniacz mleka",
+        "MILK_FROTHER_CLEANING": "Spieniacz mleka (czyszczenie)"
+      },
+      "switches": {
+        "none": "Brak",
+        "water_spout": "Wylewka wodna",
+        "motor_up": "Silnik w górę",
+        "motor_down": "Silnik w dół",
+        "coffee_waste_container": "Pojemnik na fusy",
+        "water_tank_absent": "Brak zbiornika wody",
+        "knob": "Pokrętło",
+        "water_level_low": "Niski poziom wody",
+        "coffee_jug": "Dzbanek do kawy",
+        "ifd_caraffe": "Dzbanek na mleko",
+        "ciocco_tank": "Zbiornik czekolady",
+        "clean_knob": "Pokrętło czyszczenia",
+        "door_opened": "Drzwi otwarte",
+        "preground_door_opened": "Otwarta klapka mielonej kawy"
       }
     }
   }

--- a/custom_components/delonghi_primadonna/translations/pl.json
+++ b/custom_components/delonghi_primadonna/translations/pl.json
@@ -59,11 +59,11 @@
       "nozzle_status": {
         "name": "Stan dyszy",
         "state": {
-          "UNKNOWN": "Nieznany",
-          "DETACHED": "Odłączona",
-          "STEAM": "Para",
-          "MILK_FROTHER": "Spieniacz mleka",
-          "MILK_FROTHER_CLEANING": "Spieniacz mleka (czyszczenie)"
+          "unknown": "Nieznany",
+          "detached": "Odłączona",
+          "steam": "Para",
+          "milk_frother": "Spieniacz mleka",
+          "milk_frother_cleaning": "Spieniacz mleka (czyszczenie)"
         }
       },
       "switches": {

--- a/custom_components/delonghi_primadonna/translations/ro.json
+++ b/custom_components/delonghi_primadonna/translations/ro.json
@@ -57,10 +57,33 @@
     },
     "sensor": {
       "nozzle_status": {
-        "name": "Starea duzei"
+        "name": "Starea duzei",
+        "state": {
+          "UNKNOWN": "Necunoscut",
+          "DETACHED": "Detașată",
+          "STEAM": "Abur",
+          "MILK_FROTHER": "Spumator de lapte",
+          "MILK_FROTHER_CLEANING": "Spumator de lapte (curățare)"
+        }
       },
       "switches": {
-        "name": "Comutatoare"
+        "name": "Comutatoare",
+        "state": {
+          "none": "Niciuna",
+          "water_spout": "Gura de apă",
+          "motor_up": "Motor sus",
+          "motor_down": "Motor jos",
+          "coffee_waste_container": "Recipient zaț de cafea",
+          "water_tank_absent": "Lipsă rezervor apă",
+          "knob": "Buton",
+          "water_level_low": "Nivel scăzut de apă",
+          "coffee_jug": "Carafă de cafea",
+          "ifd_caraffe": "Carafă de lapte",
+          "ciocco_tank": "Recipient ciocolată",
+          "clean_knob": "Buton curățare",
+          "door_opened": "Ușă deschisă",
+          "preground_door_opened": "Compartiment cafea măcinată deschis"
+        }
       }
     }
   },
@@ -92,33 +115,6 @@
         "espresso": "Espresso",
         "americano": "Americano",
         "espresso2": "Espresso 2"
-      }
-    }
-  },
-  "state": {
-    "sensor": {
-      "nozzle_status": {
-        "UNKNOWN": "Necunoscut",
-        "DETACHED": "Detașată",
-        "STEAM": "Abur",
-        "MILK_FROTHER": "Spumator de lapte",
-        "MILK_FROTHER_CLEANING": "Spumator de lapte (curățare)"
-      },
-      "switches": {
-        "none": "Niciuna",
-        "water_spout": "Gura de apă",
-        "motor_up": "Motor sus",
-        "motor_down": "Motor jos",
-        "coffee_waste_container": "Recipient zaț de cafea",
-        "water_tank_absent": "Lipsă rezervor apă",
-        "knob": "Buton",
-        "water_level_low": "Nivel scăzut de apă",
-        "coffee_jug": "Carafă de cafea",
-        "ifd_caraffe": "Carafă de lapte",
-        "ciocco_tank": "Recipient ciocolată",
-        "clean_knob": "Buton curățare",
-        "door_opened": "Ușă deschisă",
-        "preground_door_opened": "Compartiment cafea măcinată deschis"
       }
     }
   }

--- a/custom_components/delonghi_primadonna/translations/ro.json
+++ b/custom_components/delonghi_primadonna/translations/ro.json
@@ -54,6 +54,14 @@
       "sounds": {
         "name": "Sunete"
       }
+    },
+    "sensor": {
+      "nozzle_status": {
+        "name": "Starea duzei"
+      },
+      "switches": {
+        "name": "Comutatoare"
+      }
     }
   },
   "services": {
@@ -84,6 +92,33 @@
         "espresso": "Espresso",
         "americano": "Americano",
         "espresso2": "Espresso 2"
+      }
+    }
+  },
+  "state": {
+    "sensor": {
+      "nozzle_status": {
+        "UNKNOWN": "Necunoscut",
+        "DETACHED": "Detașată",
+        "STEAM": "Abur",
+        "MILK_FROTHER": "Spumator de lapte",
+        "MILK_FROTHER_CLEANING": "Spumator de lapte (curățare)"
+      },
+      "switches": {
+        "none": "Niciuna",
+        "water_spout": "Gura de apă",
+        "motor_up": "Motor sus",
+        "motor_down": "Motor jos",
+        "coffee_waste_container": "Recipient zaț de cafea",
+        "water_tank_absent": "Lipsă rezervor apă",
+        "knob": "Buton",
+        "water_level_low": "Nivel scăzut de apă",
+        "coffee_jug": "Carafă de cafea",
+        "ifd_caraffe": "Carafă de lapte",
+        "ciocco_tank": "Recipient ciocolată",
+        "clean_knob": "Buton curățare",
+        "door_opened": "Ușă deschisă",
+        "preground_door_opened": "Compartiment cafea măcinată deschis"
       }
     }
   }

--- a/custom_components/delonghi_primadonna/translations/ro.json
+++ b/custom_components/delonghi_primadonna/translations/ro.json
@@ -59,11 +59,11 @@
       "nozzle_status": {
         "name": "Starea duzei",
         "state": {
-          "UNKNOWN": "Necunoscut",
-          "DETACHED": "Detașată",
-          "STEAM": "Abur",
-          "MILK_FROTHER": "Spumator de lapte",
-          "MILK_FROTHER_CLEANING": "Spumator de lapte (curățare)"
+          "unknown": "Necunoscut",
+          "detached": "Detașată",
+          "steam": "Abur",
+          "milk_frother": "Spumator de lapte",
+          "milk_frother_cleaning": "Spumator de lapte (curățare)"
         }
       },
       "switches": {

--- a/custom_components/delonghi_primadonna/translations/ru.json
+++ b/custom_components/delonghi_primadonna/translations/ru.json
@@ -57,37 +57,33 @@
     },
     "sensor": {
       "nozzle_status": {
-        "name": "Статус насадки"
+        "name": "Статус насадки",
+        "state": {
+          "UNKNOWN": "Неизвестно",
+          "DETACHED": "Отсоединена",
+          "STEAM": "Паровая насадка",
+          "MILK_FROTHER": "Капучинатор",
+          "MILK_FROTHER_CLEANING": "Капучинатор (чистка)"
+        }
       },
       "switches": {
-        "name": "Переключатели"
-      }
-    }
-  },
-  "state": {
-    "sensor": {
-      "nozzle_status": {
-        "UNKNOWN": "Неизвестно",
-        "DETACHED": "Отсоединена",
-        "STEAM": "Паровая насадка",
-        "MILK_FROTHER": "Капучинатор",
-        "MILK_FROTHER_CLEANING": "Капучинатор (чистка)"
-      },
-      "switches": {
-        "none": "Нет",
-        "water_spout": "Вывод воды",
-        "motor_up": "Двигатель вверх",
-        "motor_down": "Двигатель вниз",
-        "coffee_waste_container": "Контейнер для отходов кофе",
-        "water_tank_absent": "Нет резервуара для воды",
-        "knob": "Ручка",
-        "water_level_low": "Низкий уровень воды",
-        "coffee_jug": "Кофейник",
-        "ifd_caraffe": "Молочник",
-        "ciocco_tank": "Емкость для шоколада",
-        "clean_knob": "Ручка очистки",
-        "door_opened": "Дверца открыта",
-        "preground_door_opened": "Отсек молотого кофе открыт"
+        "name": "Переключатели",
+        "state": {
+          "none": "Нет",
+          "water_spout": "Вывод воды",
+          "motor_up": "Двигатель вверх",
+          "motor_down": "Двигатель вниз",
+          "coffee_waste_container": "Контейнер для отходов кофе",
+          "water_tank_absent": "Нет резервуара для воды",
+          "knob": "Ручка",
+          "water_level_low": "Низкий уровень воды",
+          "coffee_jug": "Кофейник",
+          "ifd_caraffe": "Молочник",
+          "ciocco_tank": "Емкость для шоколада",
+          "clean_knob": "Ручка очистки",
+          "door_opened": "Дверца открыта",
+          "preground_door_opened": "Отсек молотого кофе открыт"
+        }
       }
     }
   },

--- a/custom_components/delonghi_primadonna/translations/ru.json
+++ b/custom_components/delonghi_primadonna/translations/ru.json
@@ -59,11 +59,11 @@
       "nozzle_status": {
         "name": "Статус насадки",
         "state": {
-          "UNKNOWN": "Неизвестно",
-          "DETACHED": "Отсоединена",
-          "STEAM": "Паровая насадка",
-          "MILK_FROTHER": "Капучинатор",
-          "MILK_FROTHER_CLEANING": "Капучинатор (чистка)"
+          "unknown": "Неизвестно",
+          "detached": "Отсоединена",
+          "steam": "Паровая насадка",
+          "milk_frother": "Капучинатор",
+          "milk_frother_cleaning": "Капучинатор (чистка)"
         }
       },
       "switches": {

--- a/custom_components/delonghi_primadonna/translations/ru.json
+++ b/custom_components/delonghi_primadonna/translations/ru.json
@@ -54,6 +54,41 @@
       "sounds": {
         "name": "Звук кнопок"
       }
+    },
+    "sensor": {
+      "nozzle_status": {
+        "name": "Статус насадки"
+      },
+      "switches": {
+        "name": "Переключатели"
+      }
+    }
+  },
+  "state": {
+    "sensor": {
+      "nozzle_status": {
+        "UNKNOWN": "Неизвестно",
+        "DETACHED": "Отсоединена",
+        "STEAM": "Паровая насадка",
+        "MILK_FROTHER": "Капучинатор",
+        "MILK_FROTHER_CLEANING": "Капучинатор (чистка)"
+      },
+      "switches": {
+        "none": "Нет",
+        "water_spout": "Вывод воды",
+        "motor_up": "Двигатель вверх",
+        "motor_down": "Двигатель вниз",
+        "coffee_waste_container": "Контейнер для отходов кофе",
+        "water_tank_absent": "Нет резервуара для воды",
+        "knob": "Ручка",
+        "water_level_low": "Низкий уровень воды",
+        "coffee_jug": "Кофейник",
+        "ifd_caraffe": "Молочник",
+        "ciocco_tank": "Емкость для шоколада",
+        "clean_knob": "Ручка очистки",
+        "door_opened": "Дверца открыта",
+        "preground_door_opened": "Отсек молотого кофе открыт"
+      }
     }
   },
   "services": {

--- a/custom_components/delonghi_primadonna/translations/zh-Hans.json
+++ b/custom_components/delonghi_primadonna/translations/zh-Hans.json
@@ -59,11 +59,11 @@
       "nozzle_status": {
         "name": "喷嘴状态",
         "state": {
-          "UNKNOWN": "未知",
-          "DETACHED": "已拆卸",
-          "STEAM": "蒸汽",
-          "MILK_FROTHER": "奶泥器",
-          "MILK_FROTHER_CLEANING": "奶泥器（清洗）"
+          "unknown": "未知",
+          "detached": "已拆卸",
+          "steam": "蒸汽",
+          "milk_frother": "奶泥器",
+          "milk_frother_cleaning": "奶泥器（清洗）"
         }
       },
       "switches": {

--- a/custom_components/delonghi_primadonna/translations/zh-Hans.json
+++ b/custom_components/delonghi_primadonna/translations/zh-Hans.json
@@ -54,6 +54,14 @@
       "sounds": {
         "name": "听起来"
       }
+    },
+    "sensor": {
+      "nozzle_status": {
+        "name": "喷嘴状态"
+      },
+      "switches": {
+        "name": "开关"
+      }
     }
   },
   "services": {
@@ -84,6 +92,33 @@
         "espresso": "浓缩咖啡",
         "americano": "美国",
         "espresso2": "浓缩咖啡2"
+      }
+    }
+  },
+  "state": {
+    "sensor": {
+      "nozzle_status": {
+        "UNKNOWN": "未知",
+        "DETACHED": "已拆卸",
+        "STEAM": "蒸汽",
+        "MILK_FROTHER": "奶泥器",
+        "MILK_FROTHER_CLEANING": "奶泥器（清洗）"
+      },
+      "switches": {
+        "none": "无",
+        "water_spout": "出水口",
+        "motor_up": "电机上升",
+        "motor_down": "电机下降",
+        "coffee_waste_container": "咖啡泥容器",
+        "water_tank_absent": "缺少水罐",
+        "knob": "旋钮",
+        "water_level_low": "水位低",
+        "coffee_jug": "咖啡壶",
+        "ifd_caraffe": "牛奶壶",
+        "ciocco_tank": "巧克力罐",
+        "clean_knob": "清洗旋钮",
+        "door_opened": "门已打开",
+        "preground_door_opened": "粉仓已打开"
       }
     }
   }

--- a/custom_components/delonghi_primadonna/translations/zh-Hans.json
+++ b/custom_components/delonghi_primadonna/translations/zh-Hans.json
@@ -57,10 +57,33 @@
     },
     "sensor": {
       "nozzle_status": {
-        "name": "喷嘴状态"
+        "name": "喷嘴状态",
+        "state": {
+          "UNKNOWN": "未知",
+          "DETACHED": "已拆卸",
+          "STEAM": "蒸汽",
+          "MILK_FROTHER": "奶泥器",
+          "MILK_FROTHER_CLEANING": "奶泥器（清洗）"
+        }
       },
       "switches": {
-        "name": "开关"
+        "name": "开关",
+        "state": {
+          "none": "无",
+          "water_spout": "出水口",
+          "motor_up": "电机上升",
+          "motor_down": "电机下降",
+          "coffee_waste_container": "咖啡泥容器",
+          "water_tank_absent": "缺少水罐",
+          "knob": "旋钮",
+          "water_level_low": "水位低",
+          "coffee_jug": "咖啡壶",
+          "ifd_caraffe": "牛奶壶",
+          "ciocco_tank": "巧克力罐",
+          "clean_knob": "清洗旋钮",
+          "door_opened": "门已打开",
+          "preground_door_opened": "粉仓已打开"
+        }
       }
     }
   },
@@ -92,33 +115,6 @@
         "espresso": "浓缩咖啡",
         "americano": "美国",
         "espresso2": "浓缩咖啡2"
-      }
-    }
-  },
-  "state": {
-    "sensor": {
-      "nozzle_status": {
-        "UNKNOWN": "未知",
-        "DETACHED": "已拆卸",
-        "STEAM": "蒸汽",
-        "MILK_FROTHER": "奶泥器",
-        "MILK_FROTHER_CLEANING": "奶泥器（清洗）"
-      },
-      "switches": {
-        "none": "无",
-        "water_spout": "出水口",
-        "motor_up": "电机上升",
-        "motor_down": "电机下降",
-        "coffee_waste_container": "咖啡泥容器",
-        "water_tank_absent": "缺少水罐",
-        "knob": "旋钮",
-        "water_level_low": "水位低",
-        "coffee_jug": "咖啡壶",
-        "ifd_caraffe": "牛奶壶",
-        "ciocco_tank": "巧克力罐",
-        "clean_knob": "清洗旋钮",
-        "door_opened": "门已打开",
-        "preground_door_opened": "粉仓已打开"
       }
     }
   }


### PR DESCRIPTION
## Summary
- add sensor translations for Nozzle Status and Switches across all languages
- expose translation keys for nozzle and switches sensors
- translate sensor state values in English, Russian and all other locales

## Testing
- `flake8 custom_components`
- `isort --diff --check-only custom_components`


------
https://chatgpt.com/codex/tasks/task_e_686feb2b506c8320add977d761f1a4f4

## Summary by Sourcery

Add translation support for nozzle status and switches sensors

New Features:
- Replace static sensor names with translation keys for nozzle status and switches
- Populate translation files with localized labels and state values across all supported languages