### PR TITLE
Fix StrEnum import for HA 2025.7.2

### DIFF
--- a/custom_components/delonghi_primadonna/device.py
+++ b/custom_components/delonghi_primadonna/device.py
@@ -1,7 +1,12 @@
 """Delongi primadonna device description"""
 import asyncio
 import copy
-import enum
+
+try:
+    from enum import StrEnum
+except ImportError:  # pragma: no cover - fallback for older Home Assistant
+    from homeassistant.backports.enum import StrEnum
+
 import logging
 import uuid
 import warnings
@@ -43,7 +48,7 @@ class BeverageEntityFeature(IntFlag):
     SET_INTENCE = 4
 
 
-class AvailableBeverage(enum.StrEnum):
+class AvailableBeverage(StrEnum):
     """Coffee machine available beverages"""
 
     NONE = 'none'
@@ -81,7 +86,7 @@ DEVICE_STATUS = {
 }
 
 
-class NotificationType(enum.StrEnum):
+class NotificationType(StrEnum):
     """Coffee machine notification types"""
 
     STATUS = 'status'

--- a/custom_components/delonghi_primadonna/machine_entities.py
+++ b/custom_components/delonghi_primadonna/machine_entities.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from enum import StrEnum
+
+try:
+    from enum import StrEnum
+except ImportError:  # pragma: no cover - fallback for older Home Assistant
+    from homeassistant.backports.enum import StrEnum
+
 from typing import Any
 
 


### PR DESCRIPTION
## Summary
- support HA 2025.7.2 by importing `StrEnum` from the stdlib when available
- drop unused import

## Testing
- `isort --diff --check-only custom_components && flake8 custom_components`

------
https://chatgpt.com/codex/tasks/task_e_68815fe7a8108320bd1f73ab53e5cc0a

## Summary by Sourcery

Ensure compatibility with Home Assistant 2025.7.2 by updating StrEnum imports and cleaning up unused code

Enhancements:
- Import StrEnum from the standard library when available to support Home Assistant 2025.7.2
- Replace all enum.StrEnum references with StrEnum
- Remove unused import of enum