### PR TITLE
Fix lint issues

### DIFF
--- a/custom_components/delonghi_primadonna/__init__.py
+++ b/custom_components/delonghi_primadonna/__init__.py
@@ -50,24 +50,38 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
     local_card = Path(__file__).parents[1] / "dist" / card_name
 
-    hacs_exists = await hass.async_add_executor_job(os.path.isfile, hacs_path)
-    local_exists = await hass.async_add_executor_job(os.path.isfile, str(local_card))
+    hacs_exists = await hass.async_add_executor_job(
+        os.path.isfile, hacs_path
+    )
+    local_exists = await hass.async_add_executor_job(
+        os.path.isfile, str(local_card)
+    )
 
     if hacs_exists:
         card_url = f"/hacsfiles/{DOMAIN}/{card_name}"
         frontend.add_extra_js_url(hass, card_url, es5=True)
-        _LOGGER.debug("Registered Lovelace card from HACS path: %s", hacs_path)
+        _LOGGER.debug(
+            "Registered Lovelace card from HACS path: %s",
+            hacs_path,
+        )
     elif local_exists:
         card_url = f"/{DOMAIN}/{card_name}"
         await hass.http.async_register_static_paths(
             [StaticPathConfig(card_url, str(local_card), False)]
         )
         frontend.add_extra_js_url(hass, card_url, es5=True)
-        _LOGGER.debug("Registered Lovelace card from local dist path: %s", local_card)
+        _LOGGER.debug(
+            "Registered Lovelace card from local dist path: %s",
+            local_card,
+        )
     else:
         _LOGGER.error(
-            "Lovelace card not found in either HACS path (%s) or local dist path (%s). Card will not be registered.",
-            hacs_path, local_card
+            (
+                "Lovelace card not found in either HACS path (%s) or "
+                "local dist path (%s). Card will not be registered."
+            ),
+            hacs_path,
+            local_card,
         )
 
     async def make_beverage(call: ServiceCall) -> None:

--- a/custom_components/delonghi_primadonna/device.py
+++ b/custom_components/delonghi_primadonna/device.py
@@ -197,7 +197,10 @@ def sign_request(message: list[int]) -> None:
         DeprecationWarning,
         stacklevel=2,
     )
-    _LOGGER.warning("sign_request is deprecated and will be removed in a future release. Use binascii.crc_hqx instead.")
+    _LOGGER.warning(
+        "sign_request is deprecated and will be removed in a future release. "
+        "Use binascii.crc_hqx instead."
+    )
     _LOGGER.debug("Signing request: %s", hexlify(bytearray(message), " "))
     deviser = 0x1D0F
     for item in message[: len(message) - 2]:


### PR DESCRIPTION
## Summary
- tweak Lovelace card setup to meet line length limits
- split long deprecation warning in device utility

## Testing
- `flake8 custom_components && isort --check-only custom_components`

------
https://chatgpt.com/codex/tasks/task_e_6881d368df008320a9e29ced8e7d64f2

## Summary by Sourcery

Format long lines in Lovelace card setup and deprecation warnings to comply with linting rules.

Enhancements:
- Reflow async_add_executor_job calls into multiple lines to meet line length limits
- Split debug and error log messages in __init__.py into multiline strings for readability
- Wrap deprecation warning in device.py across multiple lines to satisfy line length checks