### PR TITLE
Add debug statistics button

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+Always ensure linting passes:
+
+- Run `isort --check-only custom_components/delonghi_primadonna`.
+- Run `flake8 custom_components/delonghi_primadonna`.
+
+Only commit changes when these checks succeed.

--- a/custom_components/delonghi_primadonna/button.py
+++ b/custom_components/delonghi_primadonna/button.py
@@ -1,12 +1,18 @@
 """Button entity definitions for Delonghi Primadonna."""
 
+import logging
+
 from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
 from .device import DelonghiDeviceEntity, DelongiPrimadonna
+
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
@@ -17,7 +23,12 @@ async def async_setup_entry(
     """Set up button entities for a config entry."""
 
     delongh_device: DelongiPrimadonna = hass.data[DOMAIN][entry.unique_id]
-    async_add_entities([DelongiPrimadonnaPowerButton(delongh_device, hass)])
+    async_add_entities(
+        [
+            DelongiPrimadonnaPowerButton(delongh_device, hass),
+            DelongiPrimadonnaStatisticsButton(delongh_device, hass),
+        ]
+    )
     return True
 
 
@@ -28,3 +39,20 @@ class DelongiPrimadonnaPowerButton(DelonghiDeviceEntity, ButtonEntity):
 
     async def async_press(self):
         self.hass.async_create_task(self.device.power_on())
+
+
+class DelongiPrimadonnaStatisticsButton(DelonghiDeviceEntity, ButtonEntity):
+    """Button to read device statistics."""
+
+    _attr_translation_key = "statistics"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available (debug mode only)."""
+        return self.device.notify
+
+    async def async_press(self) -> None:
+        """Fetch statistics from the device and log them."""
+        stats = await self.device.read_statistics()
+        _LOGGER.info("Machine statistics: %s", stats)

--- a/custom_components/delonghi_primadonna/button.py
+++ b/custom_components/delonghi_primadonna/button.py
@@ -11,7 +11,6 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import DOMAIN
 from .device import DelonghiDeviceEntity, DelongiPrimadonna
 
-
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/custom_components/delonghi_primadonna/button.py
+++ b/custom_components/delonghi_primadonna/button.py
@@ -50,9 +50,13 @@ class DelongiPrimadonnaStatisticsButton(DelonghiDeviceEntity, ButtonEntity):
     @property
     def available(self) -> bool:
         """Return if entity is available (debug mode only)."""
-        return self.device.notify
+        return super().available and self.device.notify
 
     async def async_press(self) -> None:
         """Fetch statistics from the device and log them."""
-        stats = await self.device.read_statistics()
-        _LOGGER.info("Machine statistics: %s", stats)
+        try:
+            stats = await self.device.read_statistics()
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.error("Failed to read statistics: %s", err)
+            return
+        _LOGGER.debug("Machine statistics: %s", stats)

--- a/custom_components/delonghi_primadonna/statistics.py
+++ b/custom_components/delonghi_primadonna/statistics.py
@@ -6,6 +6,8 @@ import logging
 from binascii import crc_hqx
 from typing import Protocol
 
+CRC16_CCITT_INITIAL = 0xFFFF
+
 LOGGER = logging.getLogger(__name__)
 
 
@@ -65,9 +67,8 @@ class StatisticsReader:
         if len(resp) < 9:
             raise ValueError("Response too short")
 
-        if crc_hqx(bytearray(resp[:-2]), CRC16_CCITT_INITIAL) != int.from_bytes(
-            resp[-2:], "big"
-        ):
+        crc = crc_hqx(bytearray(resp[:-2]), CRC16_CCITT_INITIAL)
+        if crc != int.from_bytes(resp[-2:], "big"):
             raise ValueError("CRC mismatch")
 
         count = resp[6]

--- a/custom_components/delonghi_primadonna/translations/de.json
+++ b/custom_components/delonghi_primadonna/translations/de.json
@@ -39,6 +39,9 @@
     "button": {
       "power_on": {
         "name": "Sich einschalten"
+      },
+      "statistics": {
+        "name": "Statistiken abrufen"
       }
     },
     "switch": {

--- a/custom_components/delonghi_primadonna/translations/en.json
+++ b/custom_components/delonghi_primadonna/translations/en.json
@@ -39,6 +39,9 @@
     "button": {
       "power_on": {
         "name": "Turn on"
+      },
+      "statistics": {
+        "name": "Get statistics"
       }
     },
     "switch": {

--- a/custom_components/delonghi_primadonna/translations/fr.json
+++ b/custom_components/delonghi_primadonna/translations/fr.json
@@ -39,6 +39,9 @@
     "button": {
       "power_on": {
         "name": "Allumer"
+      },
+      "statistics": {
+        "name": "Obtenir des statistiques"
       }
     },
     "switch": {

--- a/custom_components/delonghi_primadonna/translations/hu.json
+++ b/custom_components/delonghi_primadonna/translations/hu.json
@@ -39,6 +39,9 @@
     "button": {
       "power_on": {
         "name": "Bekapcsol"
+      },
+      "statistics": {
+        "name": "Statisztika lekérése"
       }
     },
     "switch": {

--- a/custom_components/delonghi_primadonna/translations/it.json
+++ b/custom_components/delonghi_primadonna/translations/it.json
@@ -39,6 +39,9 @@
     "button": {
       "power_on": {
         "name": "Accendi"
+      },
+      "statistics": {
+        "name": "Ottieni statistiche"
       }
     },
     "switch": {

--- a/custom_components/delonghi_primadonna/translations/ja.json
+++ b/custom_components/delonghi_primadonna/translations/ja.json
@@ -39,6 +39,9 @@
     "button": {
       "power_on": {
         "name": "オンにする"
+      },
+      "statistics": {
+        "name": "統計を取得"
       }
     },
     "switch": {

--- a/custom_components/delonghi_primadonna/translations/ko.json
+++ b/custom_components/delonghi_primadonna/translations/ko.json
@@ -39,6 +39,9 @@
     "button": {
       "power_on": {
         "name": "켜십시오"
+      },
+      "statistics": {
+        "name": "통계 가져오기"
       }
     },
     "switch": {

--- a/custom_components/delonghi_primadonna/translations/pl.json
+++ b/custom_components/delonghi_primadonna/translations/pl.json
@@ -39,6 +39,9 @@
     "button": {
       "power_on": {
         "name": "Włącz"
+      },
+      "statistics": {
+        "name": "Pobierz statystyki"
       }
     },
     "switch": {

--- a/custom_components/delonghi_primadonna/translations/ro.json
+++ b/custom_components/delonghi_primadonna/translations/ro.json
@@ -39,6 +39,9 @@
     "button": {
       "power_on": {
         "name": "Porniți"
+      },
+      "statistics": {
+        "name": "Obține statistici"
       }
     },
     "switch": {

--- a/custom_components/delonghi_primadonna/translations/ru.json
+++ b/custom_components/delonghi_primadonna/translations/ru.json
@@ -39,6 +39,9 @@
     "button": {
       "power_on": {
         "name": "Включить"
+      },
+      "statistics": {
+        "name": "Получить статистику"
       }
     },
     "switch": {

--- a/custom_components/delonghi_primadonna/translations/zh-Hans.json
+++ b/custom_components/delonghi_primadonna/translations/zh-Hans.json
@@ -39,6 +39,9 @@
     "button": {
       "power_on": {
         "name": "打开"
+      },
+      "statistics": {
+        "name": "获取统计信息"
       }
     },
     "switch": {


### PR DESCRIPTION
## Summary
- add statistics button for Delonghi Primadonna available only in debug mode
- log retrieved statistics and mark button as diagnostic
- translate new button into supported languages

## Testing
- `python -m py_compile custom_components/delonghi_primadonna/button.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892411a116c83208d0d22af3d850f12

## Summary by Sourcery

Add a debug-only statistics button for Delonghi Primadonna integration

New Features:
- Provide a diagnostics-only button to fetch and log machine statistics from the device

Documentation:
- Translate the new statistics button label into all supported languages