### PR TITLE
Refactor statistics request handling

### DIFF
--- a/custom_components/delonghi_primadonna/ble_client.py
+++ b/custom_components/delonghi_primadonna/ble_client.py
@@ -261,7 +261,11 @@ class DelongiPrimadonna(MessageParser):
         await self.send_command(message)
 
     async def read_statistics(self) -> None:
-        """Request statistical parameters from the coffee machine."""
+        """Request statistical parameters from the coffee machine.
+
+        This coroutine no longer returns parsed statistics; callers should
+        consume logged output instead.
+        """
         await StatisticsReader(self).request_all()
 
     async def send_command(self, message, retries: int = 3) -> bytes | None:

--- a/custom_components/delonghi_primadonna/ble_client.py
+++ b/custom_components/delonghi_primadonna/ble_client.py
@@ -262,7 +262,7 @@ class DelongiPrimadonna(MessageParser):
 
     async def read_statistics(self) -> None:
         """Request statistical parameters from the coffee machine."""
-        await StatisticsReader(self).read_all()
+        await StatisticsReader(self).request_all()
 
     async def send_command(self, message, retries: int = 3) -> bytes | None:
         async with self._lock:

--- a/custom_components/delonghi_primadonna/ble_client.py
+++ b/custom_components/delonghi_primadonna/ble_client.py
@@ -260,9 +260,9 @@ class DelongiPrimadonna(MessageParser):
         message = [int(x, 16) for x in command.split(" ")]
         await self.send_command(message)
 
-    async def read_statistics(self) -> list[int]:
-        """Read statistical parameters from the coffee machine."""
-        return await StatisticsReader(self).read_all()
+    async def read_statistics(self) -> None:
+        """Request statistical parameters from the coffee machine."""
+        await StatisticsReader(self).read_all()
 
     async def send_command(self, message, retries: int = 3) -> bytes | None:
         async with self._lock:

--- a/custom_components/delonghi_primadonna/button.py
+++ b/custom_components/delonghi_primadonna/button.py
@@ -1,7 +1,5 @@
 """Button entity definitions for Delonghi Primadonna."""
 
-import logging
-
 from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
@@ -10,8 +8,6 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
 from .device import DelonghiDeviceEntity, DelongiPrimadonna
-
-_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
@@ -46,16 +42,6 @@ class DelongiPrimadonnaStatisticsButton(DelonghiDeviceEntity, ButtonEntity):
     _attr_translation_key = "statistics"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
-    @property
-    def available(self) -> bool:
-        """Return if entity is available (debug mode only)."""
-        return self.device.notify
-
     async def async_press(self) -> None:
-        """Fetch statistics from the device and log them."""
-        try:
-            stats = await self.device.read_statistics()
-        except Exception as err:  # noqa: BLE001
-            _LOGGER.error("Failed to read statistics: %s", err)
-            return
-        _LOGGER.debug("Machine statistics: %s", stats)
+        """Request statistics from the device."""
+        await self.device.read_statistics()

--- a/custom_components/delonghi_primadonna/const.py
+++ b/custom_components/delonghi_primadonna/const.py
@@ -52,6 +52,9 @@ BYTES_POWER = [0x0d, 0x07, 0x84, 0x0f, 0x02, 0x01, 0x55, 0x12]
 # Default bitmask for commands
 BASE_COMMAND = '10000001'
 
+# Mask used when requesting statistical parameters
+STATISTICS_PARAM_MASK = 0x0F
+
 # This command change device switches
 BYTES_SWITCH_COMMAND = [
     0x0d, 0x0b, 0x90, 0x0f, 0x00, 0x3f,

--- a/custom_components/delonghi_primadonna/const.py
+++ b/custom_components/delonghi_primadonna/const.py
@@ -55,6 +55,19 @@ BASE_COMMAND = '10000001'
 # Mask used when requesting statistical parameters
 STATISTICS_PARAM_MASK = 0x0F
 
+# Template command for requesting statistical parameters (0xA2)
+BYTES_STATISTICS_REQUEST = [
+    0x0D,
+    0x08,
+    0xA2,
+    STATISTICS_PARAM_MASK,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+]
+
 # This command change device switches
 BYTES_SWITCH_COMMAND = [
     0x0d, 0x0b, 0x90, 0x0f, 0x00, 0x3f,

--- a/custom_components/delonghi_primadonna/manifest.json
+++ b/custom_components/delonghi_primadonna/manifest.json
@@ -20,5 +20,5 @@
     "documentation": "https://github.com/Arbuzov/home_assistant_delonghi_primadonna",
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/Arbuzov/home_assistant_delonghi_primadonna/issues",
-    "version": "1.7.0"
+    "version": "1.7.1"
 }

--- a/custom_components/delonghi_primadonna/manifest.json
+++ b/custom_components/delonghi_primadonna/manifest.json
@@ -20,5 +20,5 @@
     "documentation": "https://github.com/Arbuzov/home_assistant_delonghi_primadonna",
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/Arbuzov/home_assistant_delonghi_primadonna/issues",
-    "version": "1.7.2"
+    "version": "1.7.3"
 }

--- a/custom_components/delonghi_primadonna/manifest.json
+++ b/custom_components/delonghi_primadonna/manifest.json
@@ -20,5 +20,5 @@
     "documentation": "https://github.com/Arbuzov/home_assistant_delonghi_primadonna",
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/Arbuzov/home_assistant_delonghi_primadonna/issues",
-    "version": "1.7.1"
+    "version": "1.7.2"
 }

--- a/custom_components/delonghi_primadonna/message_parser.py
+++ b/custom_components/delonghi_primadonna/message_parser.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import logging
 import uuid
-from binascii import hexlify
+from binascii import crc_hqx, hexlify
 
 from .const import AVAILABLE_PROFILES, DOMAIN
 from .machine_switch import parse_switches
@@ -22,10 +22,28 @@ START_BYTE = 0xD0
 
 
 def parse_stat_response(resp: bytes) -> list[int]:
-    """Extract integer parameters from a statistics response."""
+    """Extract integer parameters from a statistics response.
+
+    Validates packet structure and CRC to protect against malformed data.
+    """
+
+    if len(resp) < 9 or resp[0] != START_BYTE or resp[2] != 0xA2:
+        raise ValueError("Invalid statistics response")
+
+    if resp[1] + 1 != len(resp):
+        raise ValueError("Mismatched statistics length")
 
     count = resp[6]
-    data = resp[7:7 + count * 2]
+    expected_len = 7 + count * 2 + 2
+    if len(resp) != expected_len:
+        raise ValueError("Unexpected statistics payload size")
+
+    crc = int.from_bytes(resp[-2:], "big")
+    calc_crc = crc_hqx(bytearray(resp[:-2]), 0x1D0F)
+    if crc != calc_crc:
+        raise ValueError("Statistics CRC mismatch")
+
+    data = resp[7:-2]
     return [
         int.from_bytes(data[i:i + 2], "big")
         for i in range(0, len(data), 2)
@@ -143,7 +161,7 @@ class MessageParser:
                 stats = parse_stat_response(value)
             except Exception as err:  # noqa: BLE001
                 _LOGGER.warning("Failed to parse statistics response: %s", err)
-            _LOGGER.warning("Machine statistics: %s", stats)
+            _LOGGER.info("Machine statistics: %s", stats)
         hex_value = hexlify(value, " ")
         if getattr(self, "_device_status", None) != hex_value:
             _LOGGER.info("Received data: %s from %s", hex_value, sender)


### PR DESCRIPTION
## Summary
- remove availability check on statistics button
- move statistics request mask into constants
- handle `0xA2` statistics responses and log parsed values

## Testing
- `isort --check-only custom_components/delonghi_primadonna`
- `flake8 custom_components/delonghi_primadonna`

------
https://chatgpt.com/codex/tasks/task_e_6895c7eba870832088052b9bd2e9deab

## Summary by Sourcery

Centralize and simplify statistics request handling by using a constants-based packet template, moving response parsing into MessageParser, renaming and refactoring the reader and BLE client to only send requests, removing the button availability check, and logging parsed 0xA2 statistics responses.

Bug Fixes:
- Remove custom availability check on the statistics button entity

Enhancements:
- Centralize the statistics request packet in BYTES_STATISTICS_REQUEST constant
- Refactor StatisticsReader to only send requests and rename read_all to request_all
- Extract parsing of 0xA2 responses into parse_stat_response and log parsed statistics in MessageParser
- Simplify BLE client's read_statistics method and update the statistics button to just trigger requests

Chores:
- Bump component version to 1.7.2