### PR TITLE
Fix statistics response size handling

### DIFF
--- a/custom_components/delonghi_primadonna/manifest.json
+++ b/custom_components/delonghi_primadonna/manifest.json
@@ -20,5 +20,5 @@
     "documentation": "https://github.com/Arbuzov/home_assistant_delonghi_primadonna",
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/Arbuzov/home_assistant_delonghi_primadonna/issues",
-    "version": "1.7.3"
+    "version": "1.7.4"
 }

--- a/custom_components/delonghi_primadonna/manifest.json
+++ b/custom_components/delonghi_primadonna/manifest.json
@@ -20,5 +20,5 @@
     "documentation": "https://github.com/Arbuzov/home_assistant_delonghi_primadonna",
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/Arbuzov/home_assistant_delonghi_primadonna/issues",
-    "version": "1.7.4"
+    "version": "1.7.5"
 }

--- a/custom_components/delonghi_primadonna/message_parser.py
+++ b/custom_components/delonghi_primadonna/message_parser.py
@@ -59,6 +59,9 @@ def parse_stat_response(resp: bytes) -> list[int]:
 
     stats: list[int] = []
     for i in range(0, len(data), STAT_RECORD_SIZE):
+        # Each statistics record is STAT_RECORD_SIZE bytes.
+        # The first two bytes are skipped as they are reserved or unused according to the protocol specification.
+        # If the record format changes, update this logic accordingly.
         stats.append(int.from_bytes(data[i + 2:i + STAT_RECORD_SIZE], "big"))
     return stats
 


### PR DESCRIPTION
## Summary
- correctly parse A2 statistics responses with address/value pairs
- bump integration version to 1.7.4

## Testing
- `isort --check-only custom_components/delonghi_primadonna`
- `flake8 custom_components/delonghi_primadonna`


------
https://chatgpt.com/codex/tasks/task_e_6896027e58e88320a27b0991cc15f264

## Summary by Sourcery

Improve statistics response parsing by validating header length, parameter mask, payload size, CRC, and correctly extracting 4-byte values, and bump integration version.

Bug Fixes:
- Correct parsing of A2 statistics responses as address/value pairs with 4-byte values
- Validate parameter mask and payload length before processing
- Fix CRC calculation and validate against incoming CRC

Enhancements:
- Refactor parse_stat_response using defined constants for header, record, and CRC sizes to streamline record extraction

Build:
- Bump integration version to 1.7.5