### PR TITLE
Fix n_profiles attribute for machine models and add test

### DIFF
--- a/custom_components/delonghi_primadonna/ble_client.py
+++ b/custom_components/delonghi_primadonna/ble_client.py
@@ -71,8 +71,8 @@ class DelongiPrimadonna(MessageParser):
         self._last_response: bytes | None = None
         machine = get_machine_model(self.product_code)
         self._n_profiles = (
-            machine.nProfiles
-            if machine and machine.nProfiles
+            machine.n_profiles
+            if machine and machine.n_profiles
             else len(AVAILABLE_PROFILES)
         )
         for pid in range(1, self._n_profiles + 1):

--- a/custom_components/delonghi_primadonna/manifest.json
+++ b/custom_components/delonghi_primadonna/manifest.json
@@ -20,5 +20,5 @@
     "documentation": "https://github.com/Arbuzov/home_assistant_delonghi_primadonna",
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/Arbuzov/home_assistant_delonghi_primadonna/issues",
-    "version": "1.7.9"
+    "version": "1.7.10"
 }

--- a/tests/test_ble_client.py
+++ b/tests/test_ble_client.py
@@ -1,0 +1,28 @@
+import copy
+from unittest.mock import patch
+
+from custom_components.delonghi_primadonna.ble_client import (
+    AVAILABLE_PROFILES,
+    DelongiPrimadonna,
+)
+from custom_components.delonghi_primadonna.models import MachineModel
+
+
+def test_init_uses_n_profiles(hass):
+    """DelongiPrimadonna should read n_profiles from machine model."""
+    config = {"mac": "aa:bb:cc:dd:ee:ff", "name": "Test", "model": "model"}
+    machine = MachineModel(n_profiles=2)
+    profiles_backup = copy.deepcopy(AVAILABLE_PROFILES)
+    try:
+        with patch(
+            "custom_components.delonghi_primadonna.ble_client.get_machine_model",
+            return_value=machine,
+        ):
+            client = DelongiPrimadonna(config, hass)
+        assert client._n_profiles == 2
+        assert client.profiles == ["Profile 1", "Profile 2"]
+        assert list(AVAILABLE_PROFILES.keys()) == [1, 2]
+    finally:
+        AVAILABLE_PROFILES.clear()
+        AVAILABLE_PROFILES.update(profiles_backup)
+


### PR DESCRIPTION
## Summary
- handle machine profile count via `n_profiles`
- bump manifest to 1.7.10
- add unit test covering profile handling

## Testing
- `isort --check-only custom_components/delonghi_primadonna`
- `flake8 custom_components/delonghi_primadonna`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897bf35f5e88320961c504e23cf9748