### PR TITLE
Add test coverage report to workflow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -51,5 +51,17 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements_dev.txt
 
-      - name: Run tests
-        run: pytest
+      - name: Run tests with coverage
+        run: >-
+          pytest --cov=custom_components/delonghi_primadonna
+                 --cov-report=xml
+                 --cov-report=html
+                 --cov-report=term-missing
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: |
+            htmlcov
+            coverage.xml

--- a/custom_components/delonghi_primadonna/manifest.json
+++ b/custom_components/delonghi_primadonna/manifest.json
@@ -20,5 +20,5 @@
     "documentation": "https://github.com/Arbuzov/home_assistant_delonghi_primadonna",
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/Arbuzov/home_assistant_delonghi_primadonna/issues",
-    "version": "1.7.10"
+    "version": "1.7.11"
 }

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,7 @@
 isort
 flake8
 pytest
+pytest-cov
 pytest-asyncio
 pytest-homeassistant-custom-component
 pyserial


### PR DESCRIPTION
## Summary
- run unit tests with coverage in CI and upload coverage report artifact
- add pytest-cov to development requirements
- bump integration version to 1.7.11

## Testing
- `isort --check-only custom_components/delonghi_primadonna`
- `flake8 custom_components/delonghi_primadonna`
- `pytest --cov=custom_components/delonghi_primadonna --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_6897d37a068883208a8ee498ebb0fe23