### PR TITLE
Add debug statistics sensor

### DIFF
--- a/custom_components/delonghi_primadonna/ble_client.py
+++ b/custom_components/delonghi_primadonna/ble_client.py
@@ -69,6 +69,7 @@ class DelongiPrimadonna(MessageParser):
         self._rx_buffer = bytearray()
         self._response_event = None
         self._last_response: bytes | None = None
+        self.statistics: list[int] = []
         machine = get_machine_model(self.product_code)
         if machine is not None and machine.n_profiles is not None:
             self._n_profiles = machine.n_profiles

--- a/custom_components/delonghi_primadonna/manifest.json
+++ b/custom_components/delonghi_primadonna/manifest.json
@@ -20,5 +20,5 @@
     "documentation": "https://github.com/Arbuzov/home_assistant_delonghi_primadonna",
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/Arbuzov/home_assistant_delonghi_primadonna/issues",
-    "version": "1.7.12"
+    "version": "1.7.13"
 }

--- a/custom_components/delonghi_primadonna/message_parser.py
+++ b/custom_components/delonghi_primadonna/message_parser.py
@@ -177,6 +177,8 @@ class MessageParser:
                 stats = parse_stat_response(value)
             except Exception as err:  # noqa: BLE001
                 _LOGGER.warning("Failed to parse statistics response: %s", err)
+            self.statistics = stats
+            self._hass.bus.fire(f"{DOMAIN}_statistics", {"statistics": stats})
             _LOGGER.info("Machine statistics: %s", stats)
         hex_value = hexlify(value, " ")
         if getattr(self, "_device_status", None) != hex_value:


### PR DESCRIPTION
## Summary
- Add statistics debug sensor to expose beverage statistics
- Store latest statistics data and fire events when received
- Bump version to 1.7.13

## Testing
- `isort --check-only -v custom_components/delonghi_primadonna`
- `flake8 custom_components/delonghi_primadonna`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a07bb6c5708320b940f8ab6e9f5cf3