### PR TITLE
feat: add time command packet

### DIFF
--- a/custom_components/delonghi_primadonna/ble_client.py
+++ b/custom_components/delonghi_primadonna/ble_client.py
@@ -13,6 +13,7 @@ import copy
 import logging
 import uuid
 from binascii import crc_hqx, hexlify
+from datetime import datetime
 
 from bleak import BleakClient
 from bleak.exc import BleakDBusError, BleakError
@@ -23,7 +24,8 @@ from homeassistant.core import HomeAssistant
 from .const import (AVAILABLE_PROFILES, BASE_COMMAND,
                     BYTES_AUTOPOWEROFF_COMMAND, BYTES_LOAD_PROFILES,
                     BYTES_POWER, BYTES_STATISTICS_REQUEST,
-                    BYTES_SWITCH_COMMAND, BYTES_WATER_HARDNESS_COMMAND,
+                    BYTES_SWITCH_COMMAND, BYTES_TIME_COMMAND,
+                    BYTES_WATER_HARDNESS_COMMAND,
                     BYTES_WATER_TEMPERATURE_COMMAND, CONTROLL_CHARACTERISTIC,
                     DEBUG, NAME_CHARACTERISTIC, STATISTICS_BLOCKS)
 from .machine_switch import MachineSwitch
@@ -254,6 +256,13 @@ class DelongiPrimadonna(MessageParser):
         message = copy.deepcopy(BYTES_WATER_TEMPERATURE_COMMAND)
         message[9] = temperature_level
         await self.send_command(message)
+
+    async def set_time(self, dt: datetime) -> None:
+        """Set device clock from provided datetime."""
+        packet = BYTES_TIME_COMMAND.copy()
+        packet[4] = dt.hour & 0xFF
+        packet[5] = dt.minute & 0xFF
+        await self.send_command(packet)
 
     async def common_command(self, command: str) -> None:
         message = [int(x, 16) for x in command.split(" ")]

--- a/custom_components/delonghi_primadonna/const.py
+++ b/custom_components/delonghi_primadonna/const.py
@@ -107,6 +107,10 @@ BYTES_WATER_TEMPERATURE_COMMAND = [
     0x00, 0x00, 0x00, 0x00, 0x6f, 0x31
 ]
 
+BYTES_TIME_COMMAND = [
+    0x0d, 0x07, 0xE2, 0xF0, 0x00, 0x00, 0x00, 0x00
+]
+
 # Commands that load user profiles from the device. They must be
 # executed once after the first successful connection. The CRC
 # bytes are zeros as they are calculated at runtime.

--- a/custom_components/delonghi_primadonna/manifest.json
+++ b/custom_components/delonghi_primadonna/manifest.json
@@ -20,5 +20,5 @@
     "documentation": "https://github.com/Arbuzov/home_assistant_delonghi_primadonna",
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/Arbuzov/home_assistant_delonghi_primadonna/issues",
-    "version": "1.7.14"
+    "version": "1.7.15"
 }


### PR DESCRIPTION
## Summary
- add BYTES_TIME_COMMAND constant and packet builder
- support setting machine time
- build time packet within set_time to avoid double CRC
- bump integration version to 1.7.15

## Testing
- `isort --check-only custom_components/delonghi_primadonna`
- `flake8 custom_components/delonghi_primadonna`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae1a8a56308320a1cd705a975e38fc

## Summary by Sourcery

Enable setting the device clock by introducing a new time command packet and its builder, accompanied by a coverage test, and update the integration version.

New Features:
- Add BYTES_TIME_COMMAND constant and set_time method to support setting device time

Tests:
- Add test to validate time packet construction in set_time

Chores:
- Bump integration version to 1.7.15