### PR TITLE
Add datetime import and update time sync logic in DelongiPrimadonnaTi…

### DIFF
--- a/custom_components/delonghi_primadonna/switch.py
+++ b/custom_components/delonghi_primadonna/switch.py
@@ -1,5 +1,6 @@
 """Switch entities for Delonghi Primadonna."""
 
+import datetime
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
@@ -189,7 +190,7 @@ class DelongiPrimadonnaTimeSyncSwitch(
 
     def turn_on(self, **kwargs: Any) -> None:
         """Turn the sounds on."""
-        self.device.sync_time = True
+        self.hass.async_create_task(self.device.set_time(datetime.now()))
         self._attr_is_on = True
 
     def turn_off(self, **kwargs: Any) -> None:


### PR DESCRIPTION
…meSyncSwitch

## Summary by Sourcery

Use datetime.now and an async task to set the device time on switch activation instead of toggling a sync flag

Enhancements:
- Replace direct sync_time assignment with an asynchronous call to device.set_time(datetime.now())
- Add datetime import for time synchronization logic