### PR TITLE
Fix BLE connection lifecycle and frame handling

### DIFF
--- a/custom_components/delonghi_primadonna/__init__.py
+++ b/custom_components/delonghi_primadonna/__init__.py
@@ -36,7 +36,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data[DOMAIN][entry.unique_id] = delonghi_device
     _LOGGER.debug('Device id %s', entry.unique_id)
     _LOGGER.debug("Device data %s", entry.data)
-    hass.async_create_task(delonghi_device.get_device_name())
+    if hasattr(entry, "async_create_background_task"):
+        initialization_task = entry.async_create_background_task(
+            hass,
+            delonghi_device.get_device_name(),
+            "delonghi device initialization",
+        )
+    else:
+        initialization_task = hass.async_create_task(
+            delonghi_device.get_device_name()
+        )
+    delonghi_device.set_initialization_task(initialization_task)
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     async def make_beverage(call: ServiceCall) -> None:
@@ -63,12 +74,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
+    delonghi_device = hass.data[DOMAIN][entry.unique_id]
+
+    await delonghi_device.cancel_initialization()
+
     unload_ok = await hass.config_entries.async_unload_platforms(
         entry, PLATFORMS
     )
     if unload_ok:
-        await hass.data[DOMAIN][entry.unique_id].disconnect()
+        await delonghi_device.disconnect()
         hass.data[DOMAIN].pop(entry.unique_id)
+
     _LOGGER.debug('Unload %s', entry.unique_id)
     return unload_ok
 

--- a/custom_components/delonghi_primadonna/__init__.py
+++ b/custom_components/delonghi_primadonna/__init__.py
@@ -82,6 +82,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         entry, PLATFORMS
     )
     if unload_ok:
+        await delonghi_device.cancel_statistics_update()
         await delonghi_device.disconnect()
         hass.data[DOMAIN].pop(entry.unique_id)
 

--- a/custom_components/delonghi_primadonna/device.py
+++ b/custom_components/delonghi_primadonna/device.py
@@ -378,8 +378,9 @@ class DelongiPrimadonna:
         if time.monotonic() - self._last_stats_request < 60:
             return
 
-        self._statistics_task = self._hass.async_create_task(
-            self._run_statistics_update()
+        self._statistics_task = self._hass.async_create_background_task(
+            self._run_statistics_update(),
+            "delonghi statistics update",
         )
 
     async def _run_statistics_update(self) -> None:

--- a/custom_components/delonghi_primadonna/device.py
+++ b/custom_components/delonghi_primadonna/device.py
@@ -15,8 +15,9 @@ from dataclasses import dataclass
 from datetime import datetime
 from enum import IntFlag
 
-from bleak import BleakClient
 from bleak.exc import BleakDBusError, BleakError
+from bleak_retry_connector import (BleakClientWithServiceCache,
+                                   establish_connection)
 from homeassistant.components import bluetooth
 from homeassistant.const import CONF_MAC, CONF_MODEL, CONF_NAME
 from homeassistant.core import HomeAssistant
@@ -371,66 +372,67 @@ class DelongiPrimadonna:
                 self._client = None
                 self.connected = False
 
-    async def _connect(self, retries=3):
+    async def _connect(self):
         """Connect to the device."""
+        if self._client is not None and self._client.is_connected:
+            return
+
+        self._client = None
+        self.connected = False
         self._connecting = True
-        last_error = None
-        for attempt in range(retries):
-            try:
-                if self._client is None or not self._client.is_connected:
-                    self._device = bluetooth.async_ble_device_from_address(
-                        self._hass, self.mac, connectable=True
-                    )
-                    if not self._device:
-                        raise BleakError(
-                            (
-                                f"A device with address {self.mac}"
-                                " could not be found."
-                            )
-                        )
-                    self._client = BleakClient(self._device)
-                    _LOGGER.info(
-                        "Connect to %s (attempt %d)",
-                        self.mac,
-                        attempt + 1,
-                    )
-                    await asyncio.wait_for(
-                        self._client.connect(),
-                        timeout=10,
-                    )
-                    # Service discovery is performed during the connection
-                    # process. Accessing ``get_services`` directly raises a
-                    # ``FutureWarning`` in recent versions of Bleak.
-                    # ``self._client.services`` will contain the discovered
-                    # services once the connection succeeds.
-                    await asyncio.wait_for(
-                        self._client.start_notify(
-                            uuid.UUID(CONTROLL_CHARACTERISTIC),
-                            self._process_raw_data,
-                        ),
-                        timeout=10,
-                    )
-                self._connecting = False
-                return
-            except Exception as error:
-                _LOGGER.warning(
-                    "BLE connect error: %s (type: %s, attempt %d)",
-                    error,
-                    type(error).__name__,
-                    attempt + 1,
+        try:
+            self._device = bluetooth.async_ble_device_from_address(
+                self._hass, self.mac, connectable=True
+            )
+            if not self._device:
+                raise BleakError(
+                    f"A device with address {self.mac} could not be found."
                 )
-                if self._client is not None:
-                    try:
-                        await asyncio.wait_for(
-                            self._client.disconnect(), timeout=5
-                        )
-                    except Exception:  # noqa: BLE001
-                        pass
-                self._client = None
-                last_error = error
-                await asyncio.sleep(2)
-        self._connecting = False
-        raise last_error
+
+            _LOGGER.info("Connect to %s", self.mac)
+            client = await establish_connection(
+                BleakClientWithServiceCache,
+                self._device,
+                self.name or self.mac,
+                max_attempts=3,
+            )
+            self._client = client
+
+            try:
+                await asyncio.wait_for(
+                    client.start_notify(
+                        uuid.UUID(CONTROLL_CHARACTERISTIC),
+                        self._process_raw_data,
+                    ),
+                    timeout=10,
+                )
+            except asyncio.CancelledError:
+                try:
+                    await asyncio.wait_for(client.disconnect(), timeout=5)
+                except Exception:  # noqa: BLE001
+                    pass
+                finally:
+                    self._client = None
+                raise
+            except Exception:
+                try:
+                    await asyncio.wait_for(client.disconnect(), timeout=5)
+                except Exception:  # noqa: BLE001
+                    pass
+                finally:
+                    self._client = None
+                raise
+
+        except Exception as error:
+            self.connected = False
+            _LOGGER.warning(
+                "BLE connect error: %s (type: %s)",
+                error,
+                type(error).__name__,
+            )
+            raise
+        finally:
+            self._connecting = False
 
     def _make_switch_command(self):
         """Make hex command"""
@@ -812,12 +814,20 @@ class DelongiPrimadonna:
                     return
                 except BleakError as error:
                     self.connected = False
-                    self._client = None
                     _LOGGER.warning(
                         'BleakError: %s (attempt %d)',
                         error,
                         attempt + 1
                     )
+                    if self._client is not None:
+                        try:
+                            await asyncio.wait_for(
+                                self._client.disconnect(),
+                                timeout=5,
+                            )
+                        except Exception:  # noqa: BLE001
+                            pass
+                    self._client = None
                     await asyncio.sleep(2)
             _LOGGER.error('Failed to send command after %d attempts', retries)
 

--- a/custom_components/delonghi_primadonna/device.py
+++ b/custom_components/delonghi_primadonna/device.py
@@ -595,12 +595,15 @@ class DelongiPrimadonna:
         """Handle notifications from the device."""
         answer_id = value[2] if len(value) > 2 else None
         expected_statistics_start = self._expected_statistics_start
+        response_start = (
+            ((value[4] << 8) | value[5])
+            if answer_id == 0xA2 and len(value) >= 12
+            else None
+        )
         statistics_response_matches = (
             expected_statistics_start is not None
-            and answer_id == 0xA2
-            and len(value) >= 12
-            and ((value[4] << 8) | value[5])
-            == expected_statistics_start
+            and response_start is not None
+            and response_start >= expected_statistics_start
         )
 
         if answer_id in [0x75, 0x70]:
@@ -637,14 +640,9 @@ class DelongiPrimadonna:
             if statistics_response_matches:
                 await self._parse_statistics(value)
             else:
-                response_start = (
-                    ((value[4] << 8) | value[5])
-                    if len(value) > 5
-                    else None
-                )
                 _LOGGER.debug(
                     "Ignoring unexpected statistics response: "
-                    "expected start %s, got %s",
+                    "expected start >= %s, got %s",
                     expected_statistics_start,
                     response_start,
                 )
@@ -1035,15 +1033,15 @@ class DelongiPrimadonna:
                 return
             await asyncio.sleep(0.3)
 
-            # Request additional coffee totals range
-            # Covers: 3077-3080 (3077 is combined with 3000 for total coffee)
-            if not await self.get_statistics(3077, 4):
-                return
-            await asyncio.sleep(0.3)
-
             # Request cold milk, choco and tea statistics
             # Covers: 3017-3026 (3017=cold milk, 3021=choco, 3025=tea)
             if not await self.get_statistics(3017, 10):
+                return
+            await asyncio.sleep(0.3)
+
+            # Request optional additional coffee totals range
+            # Covers: 3077-3080 (3077 is combined with 3000 for total coffee)
+            if not await self.get_statistics(3077, 4):
                 return
             await asyncio.sleep(0.3)
 

--- a/custom_components/delonghi_primadonna/device.py
+++ b/custom_components/delonghi_primadonna/device.py
@@ -465,6 +465,7 @@ class DelongiPrimadonna:
                     ),
                     timeout=10,
                 )
+                self.connected = True
             except asyncio.CancelledError:
                 try:
                     await asyncio.wait_for(client.disconnect(), timeout=5)

--- a/custom_components/delonghi_primadonna/device.py
+++ b/custom_components/delonghi_primadonna/device.py
@@ -296,6 +296,7 @@ class DelongiPrimadonna:
         self._lock = asyncio.Lock()
         self._rx_buffer = bytearray()
         self._response_event = None
+        self._expected_statistics_start: int | None = None
         self._last_response: bytes | None = None
         self.statistics: dict[int, int | float] = {}
         self._last_stats_request = 0.0
@@ -570,12 +571,15 @@ class DelongiPrimadonna:
 
     async def _handle_data(self, sender, value):
         """Handle notifications from the device."""
-        if (
-            self._response_event is not None
-            and not self._response_event.is_set()
-        ):
-            self._response_event.set()
         answer_id = value[2] if len(value) > 2 else None
+        expected_statistics_start = self._expected_statistics_start
+        statistics_response_matches = (
+            expected_statistics_start is not None
+            and answer_id == 0xA2
+            and len(value) >= 12
+            and ((value[4] << 8) | value[5])
+            == expected_statistics_start
+        )
 
         if answer_id in [0x75, 0x70]:
             monitor_data = parse_monitor_data(value)
@@ -608,7 +612,32 @@ class DelongiPrimadonna:
             if profile_id is not None and status == 0:
                 self.active_profile_id = profile_id
         elif answer_id == 0xA2:
-            await self._parse_statistics(value)
+            if statistics_response_matches:
+                await self._parse_statistics(value)
+            else:
+                response_start = (
+                    ((value[4] << 8) | value[5])
+                    if len(value) > 5
+                    else None
+                )
+                _LOGGER.debug(
+                    "Ignoring unexpected statistics response: "
+                    "expected start %s, got %s",
+                    expected_statistics_start,
+                    response_start,
+                )
+
+        if (
+            self._response_event is not None
+            and not self._response_event.is_set()
+        ):
+            response_matches = (
+                statistics_response_matches
+                if expected_statistics_start is not None
+                else answer_id != 0xA2
+            )
+            if response_matches:
+                self._response_event.set()
 
         hex_value = hexlify(value, ' ')
 
@@ -837,7 +866,7 @@ class DelongiPrimadonna:
         message = [int(x, 16) for x in command.split(' ')]
         await self.send_command(message)
 
-    async def send_command(self, message, retries=3):
+    async def send_command(self, message, retries=3) -> bool:
         async with self._lock:
             message_to_send = copy.deepcopy(message)
             for attempt in range(retries):
@@ -851,23 +880,40 @@ class DelongiPrimadonna:
                         'Send command: %s',
                         hexlify(bytearray(message_to_send), " ")
                     )
+
                     self._response_event = asyncio.Event()
-                    await self._client.write_gatt_char(
-                        CONTROLL_CHARACTERISTIC, bytearray(message_to_send)
-                    )
+                    if (
+                        len(message_to_send) > 5
+                        and message_to_send[2] == 0xA2
+                    ):
+                        self._expected_statistics_start = (
+                            message_to_send[4] << 8
+                        ) | message_to_send[5]
+                    else:
+                        self._expected_statistics_start = None
+
+                    response_received = False
                     try:
-                        await asyncio.wait_for(
-                            self._response_event.wait(),
-                            timeout=10,
+                        await self._client.write_gatt_char(
+                            CONTROLL_CHARACTERISTIC,
+                            bytearray(message_to_send),
                         )
-                    except asyncio.TimeoutError:
-                        _LOGGER.warning(
-                            'Timeout waiting for response to command: %s',
-                            hexlify(bytearray(message_to_send), " ")
-                        )
+                        try:
+                            await asyncio.wait_for(
+                                self._response_event.wait(),
+                                timeout=10,
+                            )
+                            response_received = True
+                        except asyncio.TimeoutError:
+                            _LOGGER.warning(
+                                'Timeout waiting for response to command: %s',
+                                hexlify(bytearray(message_to_send), " ")
+                            )
                     finally:
                         self._response_event = None
-                    return
+                        self._expected_statistics_start = None
+
+                    return response_received
                 except BleakError as error:
                     self.connected = False
                     _LOGGER.warning(
@@ -885,7 +931,9 @@ class DelongiPrimadonna:
                             pass
                     self._client = None
                     await asyncio.sleep(2)
+
             _LOGGER.error('Failed to send command after %d attempts', retries)
+            return False
 
     async def _parse_statistics(self, data: bytes) -> None:
         """Parse statistics response"""
@@ -950,32 +998,37 @@ class DelongiPrimadonna:
 
             self._last_stats_request = current_time
             # Maintenance counters (100-109)
-            await self.get_statistics(100, 10)
+            if not await self.get_statistics(100, 10):
+                return
             await asyncio.sleep(0.3)
 
             # Extended maintenance (110-119)
-            await self.get_statistics(110, 10)
+            if not await self.get_statistics(110, 10):
+                return
             await asyncio.sleep(0.3)
 
             # Coffee beverage totals (3000-3009)
-            await self.get_statistics(3000, 10)
+            if not await self.get_statistics(3000, 10):
+                return
             await asyncio.sleep(0.3)
 
             # Request additional coffee totals range
             # Covers: 3077-3080 (3077 is combined with 3000 for total coffee)
-            await self.get_statistics(3077, 4)
+            if not await self.get_statistics(3077, 4):
+                return
             await asyncio.sleep(0.3)
 
             # Request cold milk, choco and tea statistics
             # Covers: 3017-3026 (3017=cold milk, 3021=choco, 3025=tea)
-            await self.get_statistics(3017, 10)
+            if not await self.get_statistics(3017, 10):
+                return
             await asyncio.sleep(0.3)
 
-    async def get_statistics(self, start_index: int, count: int) -> None:
+    async def get_statistics(self, start_index: int, count: int) -> bool:
         """Get statistics from the machine"""
         message = copy.deepcopy(BYTES_STATISTICS_COMMAND)
         message[4] = (start_index >> 8) & 0xFF
         message[5] = start_index & 0xFF
         message[6] = count
 
-        await self.send_command(message)
+        return await self.send_command(message)

--- a/custom_components/delonghi_primadonna/device.py
+++ b/custom_components/delonghi_primadonna/device.py
@@ -543,6 +543,16 @@ class DelongiPrimadonna:
             )
         _LOGGER.info('Event triggered: %s', event_data)
 
+    @staticmethod
+    def _has_valid_crc(packet: bytes) -> bool:
+        """Return whether an assembled BLE packet has a valid CRC."""
+        if len(packet) < 4:
+            return False
+
+        expected_crc = int.from_bytes(packet[-2:], byteorder='big')
+        actual_crc = crc_hqx(packet[:-2], 0x1D0F)
+        return actual_crc == expected_crc
+
     async def _process_raw_data(self, sender, value):
         """Assemble incoming BLE packets and pass complete messages."""
         self._rx_buffer.extend(value)
@@ -568,6 +578,15 @@ class DelongiPrimadonna:
                 return
 
             packet = bytes(self._rx_buffer[:msg_len])
+
+            if not self._has_valid_crc(packet):
+                _LOGGER.debug(
+                    "Discarding invalid BLE frame candidate: %s",
+                    hexlify(packet, " "),
+                )
+                del self._rx_buffer[0]
+                continue
+
             del self._rx_buffer[:msg_len]
             await self._handle_data(sender, packet)
 

--- a/custom_components/delonghi_primadonna/device.py
+++ b/custom_components/delonghi_primadonna/device.py
@@ -456,6 +456,7 @@ class DelongiPrimadonna:
             self._client = client
 
             try:
+                self._rx_buffer.clear()
                 await asyncio.wait_for(
                     client.start_notify(
                         uuid.UUID(CONTROLL_CHARACTERISTIC),

--- a/custom_components/delonghi_primadonna/device.py
+++ b/custom_components/delonghi_primadonna/device.py
@@ -300,6 +300,7 @@ class DelongiPrimadonna:
         self.statistics: dict[int, int | float] = {}
         self._last_stats_request = 0.0
         self._stats_lock = asyncio.Lock()
+        self._statistics_task: asyncio.Task | None = None
         self._initialization_task: asyncio.Task | None = None
         machine = get_machine_model(self.product_code)
         self.model = (
@@ -357,6 +358,42 @@ class DelongiPrimadonna:
         """Cancel and wait for device initialization."""
         task = self._initialization_task
         self._initialization_task = None
+
+        if task is None or task.done():
+            return
+
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    def schedule_statistics_update(self) -> None:
+        """Schedule a statistics update when needed."""
+        task = self._statistics_task
+        if task is not None and not task.done():
+            return
+
+        if time.monotonic() - self._last_stats_request < 60:
+            return
+
+        self._statistics_task = self._hass.async_create_task(
+            self._run_statistics_update()
+        )
+
+    async def _run_statistics_update(self) -> None:
+        """Run a managed statistics update."""
+        try:
+            await self.update_statistics()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            _LOGGER.exception("Statistics update failed")
+
+    async def cancel_statistics_update(self) -> None:
+        """Cancel and wait for a pending statistics update."""
+        task = self._statistics_task
+        self._statistics_task = None
 
         if task is None or task.done():
             return

--- a/custom_components/delonghi_primadonna/device.py
+++ b/custom_components/delonghi_primadonna/device.py
@@ -1014,12 +1014,13 @@ class DelongiPrimadonna:
 
         async with self._stats_lock:
             current_time = time.monotonic()
-            # Update at most once every 60 seconds
+            # Attempt statistics polling at most once every 60 seconds,
+            # including failed attempts, to avoid repeated BLE retries.
             if current_time - self._last_stats_request < 60:
                 return
 
             self._last_stats_request = current_time
-            # Maintenance counters (100-109)
+            # Start sparse statistics sequence at parameter 100
             if not await self.get_statistics(100, 10):
                 return
             await asyncio.sleep(0.3)

--- a/custom_components/delonghi_primadonna/device.py
+++ b/custom_components/delonghi_primadonna/device.py
@@ -1024,8 +1024,8 @@ class DelongiPrimadonna:
                 return
             await asyncio.sleep(0.3)
 
-            # Extended maintenance (110-119)
-            if not await self.get_statistics(110, 10):
+            # Continue sparse statistics from parameter 111
+            if not await self.get_statistics(111, 10):
                 return
             await asyncio.sleep(0.3)
 

--- a/custom_components/delonghi_primadonna/device.py
+++ b/custom_components/delonghi_primadonna/device.py
@@ -300,6 +300,7 @@ class DelongiPrimadonna:
         self.statistics: dict[int, int | float] = {}
         self._last_stats_request = 0.0
         self._stats_lock = asyncio.Lock()
+        self._initialization_task: asyncio.Task | None = None
         machine = get_machine_model(self.product_code)
         self.model = (
             machine.name if machine and machine.name else 'Prima Donna'
@@ -347,6 +348,24 @@ class DelongiPrimadonna:
         if len(self.available_beverages) <= 1:
             # Fallback to legacy enum if no recipes
             self.available_beverages = [*AvailableBeverage]
+
+    def set_initialization_task(self, task: asyncio.Task) -> None:
+        """Track the device initialization task."""
+        self._initialization_task = task
+
+    async def cancel_initialization(self) -> None:
+        """Cancel and wait for device initialization."""
+        task = self._initialization_task
+        self._initialization_task = None
+
+        if task is None or task.done():
+            return
+
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
 
     async def disconnect(self):
         """Disconnect from the device."""
@@ -732,9 +751,9 @@ class DelongiPrimadonna:
             except asyncio.exceptions.TimeoutError as error:
                 self.connected = False
                 _LOGGER.info('TimeoutError: %s at device connection', error)
-            except asyncio.exceptions.CancelledError as error:
+            except asyncio.CancelledError:
                 self.connected = False
-                _LOGGER.warning('CancelledError: %s', error)
+                raise
 
         if self.connected and not self._profiles_loaded:
             command = BYTES_LOAD_PROFILES.copy()

--- a/custom_components/delonghi_primadonna/device_tracker.py
+++ b/custom_components/delonghi_primadonna/device_tracker.py
@@ -1,5 +1,7 @@
 """Device tracker entity for Delonghi Primadonna."""
 
+import asyncio
+
 from homeassistant.components.device_tracker.config_entry import ScannerEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -25,6 +27,7 @@ async def async_setup_entry(
 class DelongiPrimadonnaDeviceTracker(DelonghiDeviceEntity, ScannerEntity):
     """Implementation of a Delonghi Primadonna device tracker"""
     _attr_name = None
+    _device_name_task: asyncio.Task | None = None
 
     @property
     def icon(self) -> str:
@@ -56,5 +59,23 @@ class DelongiPrimadonnaDeviceTracker(DelonghiDeviceEntity, ScannerEntity):
         return self.device.connected
 
     async def async_update(self):
-        """Updates the device status"""
-        self.hass.async_create_task(self.device.get_device_name())
+        """Update the device status."""
+        task = self._device_name_task
+        if task is None or task.done():
+            self._device_name_task = self.hass.async_create_task(
+                self.device.get_device_name()
+            )
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Cancel the pending device status update."""
+        task = self._device_name_task
+        self._device_name_task = None
+
+        if task is not None and not task.done():
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        await super().async_will_remove_from_hass()

--- a/custom_components/delonghi_primadonna/device_tracker.py
+++ b/custom_components/delonghi_primadonna/device_tracker.py
@@ -62,8 +62,9 @@ class DelongiPrimadonnaDeviceTracker(DelonghiDeviceEntity, ScannerEntity):
         """Update the device status."""
         task = self._device_name_task
         if task is None or task.done():
-            self._device_name_task = self.hass.async_create_task(
-                self.device.get_device_name()
+            self._device_name_task = self.hass.async_create_background_task(
+                self.device.get_device_name(),
+                "delonghi device tracker update",
             )
 
     async def async_will_remove_from_hass(self) -> None:

--- a/custom_components/delonghi_primadonna/sensor.py
+++ b/custom_components/delonghi_primadonna/sensor.py
@@ -83,7 +83,6 @@ async def async_setup_entry(
         ]
     )
 
-    hass.async_create_task(delongh_device.update_statistics())
     return True
 
 
@@ -248,9 +247,7 @@ class DelongiPrimadonnaStatisticsSensor(
     async def async_update(self) -> None:
         """Fetch new state data for the sensor."""
         if self.device.connected:
-            self.hass.async_create_task(
-                self.device.update_statistics()
-            )
+            self.device.schedule_statistics_update()
 
 
 class DelongiPrimadonnaUtilitySensor(DelongiPrimadonnaStatisticsSensor):

--- a/tests/test_ble_lifecycle.py
+++ b/tests/test_ble_lifecycle.py
@@ -1,0 +1,399 @@
+import asyncio
+import os
+import sys
+import time
+
+from bleak.exc import BleakError
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "custom_components",
+        )
+    )
+)
+
+import delonghi_primadonna.device as device_module  # noqa: E402
+from delonghi_primadonna.const import BYTES_STATISTICS_COMMAND  # noqa: E402
+from delonghi_primadonna.device import DelongiPrimadonna  # noqa: E402
+from delonghi_primadonna.device_tracker import \
+    DelongiPrimadonnaDeviceTracker  # noqa: E402
+
+CONFIG = {
+    "mac": "00:11:22:33:44:55",
+    "model": "TEST",
+    "name": "TEST",
+}
+
+
+def make_device(hass=None):
+    return DelongiPrimadonna(CONFIG, hass)
+
+
+class FakeHass:
+    def __init__(self):
+        self.created_tasks = []
+
+    def async_create_task(self, coro):
+        task = asyncio.create_task(coro)
+        self.created_tasks.append(task)
+        return task
+
+
+class FakeConnectClient:
+    def __init__(
+        self,
+        *,
+        notify_error=None,
+        block_notify=False,
+    ):
+        self.is_connected = True
+        self.notify_error = notify_error
+        self.block_notify = block_notify
+        self.notify_started = asyncio.Event()
+        self.notify_release = asyncio.Event()
+        self.start_notify_calls = 0
+        self.disconnect_calls = 0
+
+    async def start_notify(self, _characteristic, _callback):
+        self.start_notify_calls += 1
+        self.notify_started.set()
+
+        if self.notify_error is not None:
+            raise self.notify_error
+
+        if self.block_notify:
+            await self.notify_release.wait()
+
+    async def disconnect(self):
+        self.disconnect_calls += 1
+        self.is_connected = False
+
+
+class FailingWriteClient:
+    is_connected = True
+
+    def __init__(self):
+        self.disconnect_calls = 0
+
+    async def write_gatt_char(
+        self,
+        _characteristic,
+        _message,
+    ):
+        raise BleakError("write failed")
+
+    async def disconnect(self):
+        self.disconnect_calls += 1
+        self.is_connected = False
+
+
+async def run_with_fake_connection(device, client):
+    original_lookup = (
+        device_module.bluetooth.async_ble_device_from_address
+    )
+    original_establish = device_module.establish_connection
+
+    fake_ble_device = object()
+
+    def fake_lookup(_hass, _mac, connectable):
+        assert connectable is True
+        return fake_ble_device
+
+    async def fake_establish(
+        _client_class,
+        ble_device,
+        _name,
+        max_attempts,
+    ):
+        assert ble_device is fake_ble_device
+        assert max_attempts == 3
+        return client
+
+    device_module.bluetooth.async_ble_device_from_address = (
+        fake_lookup
+    )
+    device_module.establish_connection = fake_establish
+
+    try:
+        await device._connect()
+    finally:
+        device_module.bluetooth.async_ble_device_from_address = (
+            original_lookup
+        )
+        device_module.establish_connection = original_establish
+
+
+async def test_connect_success():
+    device = make_device()
+    client = FakeConnectClient()
+
+    await run_with_fake_connection(device, client)
+
+    assert device._client is client
+    assert client.start_notify_calls == 1
+    assert client.disconnect_calls == 0
+    assert device._connecting is False
+
+
+async def test_notify_failure_disconnects_client():
+    device = make_device()
+    client = FakeConnectClient(
+        notify_error=BleakError("notify failed")
+    )
+
+    try:
+        await run_with_fake_connection(device, client)
+    except BleakError:
+        pass
+    else:
+        raise AssertionError(
+            "_connect did not propagate start_notify failure"
+        )
+
+    assert client.disconnect_calls == 1
+    assert device._client is None
+    assert device.connected is False
+    assert device._connecting is False
+
+
+async def test_connect_cancellation_disconnects_client():
+    device = make_device()
+    client = FakeConnectClient(block_notify=True)
+
+    original_lookup = (
+        device_module.bluetooth.async_ble_device_from_address
+    )
+    original_establish = device_module.establish_connection
+
+    fake_ble_device = object()
+
+    def fake_lookup(_hass, _mac, connectable):
+        assert connectable is True
+        return fake_ble_device
+
+    async def fake_establish(
+        _client_class,
+        ble_device,
+        _name,
+        max_attempts,
+    ):
+        assert ble_device is fake_ble_device
+        assert max_attempts == 3
+        return client
+
+    device_module.bluetooth.async_ble_device_from_address = (
+        fake_lookup
+    )
+    device_module.establish_connection = fake_establish
+
+    task = asyncio.create_task(device._connect())
+
+    try:
+        await client.notify_started.wait()
+
+        task.cancel()
+
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        else:
+            raise AssertionError(
+                "_connect did not propagate cancellation"
+            )
+    finally:
+        device_module.bluetooth.async_ble_device_from_address = (
+            original_lookup
+        )
+        device_module.establish_connection = original_establish
+
+    assert client.disconnect_calls == 1
+    assert device._client is None
+    assert device._connecting is False
+
+
+async def test_write_bleak_error_disconnects_client():
+    device = make_device()
+    client = FailingWriteClient()
+    device._client = client
+
+    async def fake_connect():
+        return None
+
+    device._connect = fake_connect
+
+    original_sleep = device_module.asyncio.sleep
+
+    async def no_sleep(_delay):
+        return None
+
+    device_module.asyncio.sleep = no_sleep
+
+    try:
+        result = await device.send_command(
+            list(BYTES_STATISTICS_COMMAND),
+            retries=1,
+        )
+    finally:
+        device_module.asyncio.sleep = original_sleep
+
+    assert result is False
+    assert client.disconnect_calls == 1
+    assert device._client is None
+    assert device.connected is False
+
+
+async def test_initialization_task_is_cancelled_and_awaited():
+    device = make_device()
+
+    started = asyncio.Event()
+    cleaned_up = asyncio.Event()
+
+    async def initialization():
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            cleaned_up.set()
+
+    task = asyncio.create_task(initialization())
+    device.set_initialization_task(task)
+
+    await started.wait()
+    await device.cancel_initialization()
+
+    assert device._initialization_task is None
+    assert task.cancelled()
+    assert cleaned_up.is_set()
+
+
+async def test_get_device_name_propagates_cancellation():
+    device = make_device()
+
+    async def cancelled_connect():
+        raise asyncio.CancelledError
+
+    device._connect = cancelled_connect
+
+    try:
+        await device.get_device_name()
+    except asyncio.CancelledError:
+        pass
+    else:
+        raise AssertionError(
+            "get_device_name swallowed cancellation"
+        )
+
+    assert device.connected is False
+
+
+class FakeTrackerDevice:
+    def __init__(self):
+        self.calls = 0
+        self.started = asyncio.Event()
+
+    async def get_device_name(self):
+        self.calls += 1
+        self.started.set()
+        await asyncio.Event().wait()
+
+
+async def test_tracker_deduplicates_and_cancels_update():
+    hass = FakeHass()
+    fake_device = FakeTrackerDevice()
+
+    tracker = DelongiPrimadonnaDeviceTracker.__new__(
+        DelongiPrimadonnaDeviceTracker
+    )
+    tracker.hass = hass
+    tracker.device = fake_device
+    tracker._device_name_task = None
+
+    await tracker.async_update()
+    first_task = tracker._device_name_task
+
+    await tracker.async_update()
+    second_task = tracker._device_name_task
+
+    await fake_device.started.wait()
+
+    assert first_task is second_task
+    assert fake_device.calls == 1
+    assert len(hass.created_tasks) == 1
+
+    await tracker.async_will_remove_from_hass()
+
+    assert tracker._device_name_task is None
+    assert first_task.cancelled()
+
+
+async def test_statistics_task_deduplicates_and_cancels():
+    hass = FakeHass()
+    device = make_device(hass)
+
+    calls = 0
+    started = asyncio.Event()
+
+    async def statistics_update():
+        nonlocal calls
+        calls += 1
+        started.set()
+        await asyncio.Event().wait()
+
+    device.update_statistics = statistics_update
+    device._last_stats_request = 0.0
+
+    device.schedule_statistics_update()
+    first_task = device._statistics_task
+
+    device.schedule_statistics_update()
+    second_task = device._statistics_task
+
+    await started.wait()
+
+    assert first_task is second_task
+    assert calls == 1
+    assert len(hass.created_tasks) == 1
+
+    await device.cancel_statistics_update()
+
+    assert device._statistics_task is None
+    assert first_task.cancelled()
+
+
+async def test_statistics_schedule_respects_throttle():
+    hass = FakeHass()
+    device = make_device(hass)
+
+    device._last_stats_request = time.monotonic()
+
+    device.schedule_statistics_update()
+
+    assert device._statistics_task is None
+    assert hass.created_tasks == []
+
+
+async def run_tests():
+    await test_connect_success()
+    await test_notify_failure_disconnects_client()
+    await test_connect_cancellation_disconnects_client()
+    await test_write_bleak_error_disconnects_client()
+
+    await test_initialization_task_is_cancelled_and_awaited()
+    await test_get_device_name_propagates_cancellation()
+    await test_tracker_deduplicates_and_cancels_update()
+
+    await test_statistics_task_deduplicates_and_cancels()
+    await test_statistics_schedule_respects_throttle()
+
+    print(
+        "[SUCCESS] BLE lifecycle regressions "
+        "for commits 1-3 verified."
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(run_tests())

--- a/tests/test_ble_lifecycle.py
+++ b/tests/test_ble_lifecycle.py
@@ -138,6 +138,35 @@ async def test_connect_success():
     assert device._connecting is False
 
 
+async def test_connect_clears_receive_buffer_before_notifications():
+    device = make_device()
+    device._rx_buffer.extend(
+        b"\\xd0\\x41\\xa2\\x0f\\x00"
+    )
+    client = FakeConnectClient()
+
+    observed_buffer = None
+    original_start_notify = client.start_notify
+
+    async def inspecting_start_notify(
+        characteristic,
+        callback,
+    ):
+        nonlocal observed_buffer
+        observed_buffer = bytes(device._rx_buffer)
+        await original_start_notify(
+            characteristic,
+            callback,
+        )
+
+    client.start_notify = inspecting_start_notify
+
+    await run_with_fake_connection(device, client)
+
+    assert observed_buffer == b""
+    assert device._rx_buffer == bytearray()
+
+
 async def test_notify_failure_disconnects_client():
     device = make_device()
     client = FakeConnectClient(
@@ -378,6 +407,7 @@ async def test_statistics_schedule_respects_throttle():
 
 async def run_tests():
     await test_connect_success()
+    await test_connect_clears_receive_buffer_before_notifications()
     await test_notify_failure_disconnects_client()
     await test_connect_cancellation_disconnects_client()
     await test_write_bleak_error_disconnects_client()

--- a/tests/test_ble_lifecycle.py
+++ b/tests/test_ble_lifecycle.py
@@ -488,6 +488,71 @@ async def test_statistics_task_deduplicates_and_cancels():
     assert first_task.cancelled()
 
 
+async def test_failed_statistics_attempt_is_throttled():
+    hass = FakeHass()
+    device = make_device(hass)
+    calls = []
+
+    async def failed_statistics(start_index, count):
+        calls.append((start_index, count))
+        return False
+
+    device.get_statistics = failed_statistics
+    device._last_stats_request = 0.0
+
+    before = time.monotonic()
+    await device.update_statistics()
+    after = time.monotonic()
+
+    assert calls == [(100, 10)]
+    assert before <= device._last_stats_request <= after
+
+    device.schedule_statistics_update()
+
+    assert device._statistics_task is None
+    assert hass.background_tasks == []
+
+
+async def test_statistics_update_exception_is_contained_and_reschedulable():
+    hass = FakeHass()
+    device = make_device(hass)
+    calls = 0
+
+    async def failing_statistics_update():
+        nonlocal calls
+        calls += 1
+        raise RuntimeError("statistics failed")
+
+    device.update_statistics = failing_statistics_update
+    device._last_stats_request = 0.0
+
+    device.schedule_statistics_update()
+    first_task = device._statistics_task
+
+    assert first_task is not None
+
+    await first_task
+
+    assert first_task.done()
+    assert not first_task.cancelled()
+    assert device._statistics_task is first_task
+    assert calls == 1
+
+    device.schedule_statistics_update()
+    second_task = device._statistics_task
+
+    assert second_task is not None
+    assert second_task is not first_task
+
+    await second_task
+
+    assert second_task.done()
+    assert not second_task.cancelled()
+    assert device._statistics_task is second_task
+    assert calls == 2
+    assert len(hass.background_tasks) == 2
+
+
 async def test_statistics_schedule_respects_throttle():
     hass = FakeHass()
     device = make_device(hass)
@@ -515,6 +580,8 @@ async def run_tests():
     await test_tracker_deduplicates_and_cancels_update()
 
     await test_statistics_task_deduplicates_and_cancels()
+    await test_failed_statistics_attempt_is_throttled()
+    await test_statistics_update_exception_is_contained_and_reschedulable()
     await test_statistics_schedule_respects_throttle()
 
     print(

--- a/tests/test_ble_lifecycle.py
+++ b/tests/test_ble_lifecycle.py
@@ -203,6 +203,42 @@ async def test_receive_buffer_reassembles_fragmented_packet():
     assert device._rx_buffer == bytearray()
 
 
+async def test_receive_buffer_discards_invalid_crc_packet():
+    device = make_device()
+    handled_packets = []
+
+    assert device._has_valid_crc(RX_TEST_PACKET)
+
+    corrupted_packet = bytearray(RX_TEST_PACKET)
+    corrupted_packet[-1] ^= 0x01
+    corrupted_packet = bytes(corrupted_packet)
+
+    assert not device._has_valid_crc(corrupted_packet)
+
+    device._expected_statistics_start = 100
+    device._response_event = asyncio.Event()
+
+    async def no_event(_value):
+        return None
+
+    device._event_trigger = no_event
+
+    original_handle_data = device._handle_data
+
+    async def capture_and_handle(sender, packet):
+        handled_packets.append(bytes(packet))
+        await original_handle_data(sender, packet)
+
+    device._handle_data = capture_and_handle
+
+    await device._process_raw_data(None, corrupted_packet)
+
+    assert handled_packets == []
+    assert not device._response_event.is_set()
+    assert not device.statistics
+    assert device._rx_buffer == bytearray()
+
+
 async def test_receive_buffer_recovers_from_restarted_frame():
     device = make_device()
     handled_packets = []
@@ -468,6 +504,7 @@ async def run_tests():
     await test_connect_success()
     await test_connect_clears_receive_buffer_before_notifications()
     await test_receive_buffer_reassembles_fragmented_packet()
+    await test_receive_buffer_discards_invalid_crc_packet()
     await test_receive_buffer_recovers_from_restarted_frame()
     await test_notify_failure_disconnects_client()
     await test_connect_cancellation_disconnects_client()

--- a/tests/test_ble_lifecycle.py
+++ b/tests/test_ble_lifecycle.py
@@ -139,6 +139,7 @@ async def test_connect_success():
     await run_with_fake_connection(device, client)
 
     assert device._client is client
+    assert device.connected is True
     assert client.start_notify_calls == 1
     assert client.disconnect_calls == 0
     assert device._connecting is False

--- a/tests/test_ble_lifecycle.py
+++ b/tests/test_ble_lifecycle.py
@@ -173,6 +173,56 @@ async def test_connect_clears_receive_buffer_before_notifications():
     assert device._rx_buffer == bytearray()
 
 
+RX_TEST_PACKET = bytes.fromhex(
+    "d0 41 a2 0f 00 64 2d 34 3b 42 49 50 57 5e 65 6c "
+    "73 7a 81 88 8f 96 9d a4 ab b2 b9 c0 c7 ce d5 dc "
+    "e3 ea f1 f8 ff 06 0d 14 1b 22 29 30 37 3e 45 4c "
+    "53 5a 61 68 6f 76 7d 84 8b 92 99 a0 a7 ae b5 bc "
+    "05 97"
+)
+
+
+async def test_receive_buffer_reassembles_fragmented_packet():
+    device = make_device()
+    handled_packets = []
+
+    async def capture_packet(_sender, packet):
+        handled_packets.append(bytes(packet))
+
+    device._handle_data = capture_packet
+
+    await device._process_raw_data(None, RX_TEST_PACKET[:20])
+
+    assert handled_packets == []
+    assert device._rx_buffer == bytearray(RX_TEST_PACKET[:20])
+
+    await device._process_raw_data(None, RX_TEST_PACKET[20:])
+
+    assert handled_packets == [RX_TEST_PACKET]
+    assert device._rx_buffer == bytearray()
+
+
+async def test_receive_buffer_recovers_from_restarted_frame():
+    device = make_device()
+    handled_packets = []
+
+    async def capture_packet(_sender, packet):
+        handled_packets.append(bytes(packet))
+
+    device._handle_data = capture_packet
+
+    await device._process_raw_data(None, RX_TEST_PACKET[:20])
+
+    assert handled_packets == []
+
+    # Reproduce the live failure: after a 20-byte partial packet, the
+    # device restarts transmission from the beginning of the same frame.
+    await device._process_raw_data(None, RX_TEST_PACKET)
+
+    assert handled_packets == [RX_TEST_PACKET]
+    assert device._rx_buffer == bytearray()
+
+
 async def test_notify_failure_disconnects_client():
     device = make_device()
     client = FakeConnectClient(
@@ -416,6 +466,8 @@ async def test_statistics_schedule_respects_throttle():
 async def run_tests():
     await test_connect_success()
     await test_connect_clears_receive_buffer_before_notifications()
+    await test_receive_buffer_reassembles_fragmented_packet()
+    await test_receive_buffer_recovers_from_restarted_frame()
     await test_notify_failure_disconnects_client()
     await test_connect_cancellation_disconnects_client()
     await test_write_bleak_error_disconnects_client()

--- a/tests/test_ble_lifecycle.py
+++ b/tests/test_ble_lifecycle.py
@@ -35,10 +35,16 @@ def make_device(hass=None):
 class FakeHass:
     def __init__(self):
         self.created_tasks = []
+        self.background_tasks = []
 
     def async_create_task(self, coro):
         task = asyncio.create_task(coro)
         self.created_tasks.append(task)
+        return task
+
+    def async_create_background_task(self, coro, _name):
+        task = asyncio.create_task(coro)
+        self.background_tasks.append(task)
         return task
 
 
@@ -351,7 +357,8 @@ async def test_tracker_deduplicates_and_cancels_update():
 
     assert first_task is second_task
     assert fake_device.calls == 1
-    assert len(hass.created_tasks) == 1
+    assert hass.created_tasks == []
+    assert len(hass.background_tasks) == 1
 
     await tracker.async_will_remove_from_hass()
 
@@ -385,7 +392,8 @@ async def test_statistics_task_deduplicates_and_cancels():
 
     assert first_task is second_task
     assert calls == 1
-    assert len(hass.created_tasks) == 1
+    assert hass.created_tasks == []
+    assert len(hass.background_tasks) == 1
 
     await device.cancel_statistics_update()
 

--- a/tests/test_response_correlation.py
+++ b/tests/test_response_correlation.py
@@ -1,0 +1,237 @@
+import asyncio
+import os
+import sys
+from binascii import hexlify, unhexlify
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "custom_components",
+        )
+    )
+)
+
+import delonghi_primadonna.device as device_module  # noqa: E402
+from delonghi_primadonna.const import BYTES_STATISTICS_COMMAND  # noqa: E402
+from delonghi_primadonna.device import DelongiPrimadonna  # noqa: E402
+
+CONFIG = {
+    "mac": "00:11:22:33:44:55",
+    "model": "TEST",
+    "name": "TEST",
+}
+
+LOG_PACKET = unhexlify(
+    "d041a20f00640013a89e00650000000a"
+    "00690000000f006a002365e8006c0000"
+    "0000006d00000000006f000000120074"
+    "000002840284000000000bb80000397e"
+    "54d1"
+)
+
+
+def make_device():
+    return DelongiPrimadonna(CONFIG, None)
+
+
+async def no_event(_value):
+    return None
+
+
+def statistics_message(start_index=100, count=10):
+    message = list(BYTES_STATISTICS_COMMAND)
+    message[4] = (start_index >> 8) & 0xFF
+    message[5] = start_index & 0xFF
+    message[6] = count
+    return message
+
+
+async def test_matching_statistics_response():
+    device = make_device()
+    device._expected_statistics_start = 100
+    device._response_event = asyncio.Event()
+    device._device_status = hexlify(LOG_PACKET, " ")
+    device._event_trigger = no_event
+
+    await device._handle_data(None, LOG_PACKET)
+
+    assert device._response_event.is_set()
+    assert device.statistics[100] == 1288350
+    assert device.statistics[105] == 15
+
+
+async def test_wrong_statistics_start_is_ignored():
+    device = make_device()
+    device._expected_statistics_start = 110
+    device._response_event = asyncio.Event()
+    device._device_status = hexlify(LOG_PACKET, " ")
+    device._event_trigger = no_event
+
+    await device._handle_data(None, LOG_PACKET)
+
+    assert not device._response_event.is_set()
+    assert 100 not in device.statistics
+    assert 105 not in device.statistics
+
+
+async def test_short_statistics_response_is_ignored():
+    device = make_device()
+    packet = bytes(
+        [0xD0, 0x05, 0xA2, 0x0F, 0x00, 0x64]
+    )
+
+    device._expected_statistics_start = 100
+    device._response_event = asyncio.Event()
+    device._device_status = hexlify(packet, " ")
+    device._event_trigger = no_event
+
+    await device._handle_data(None, packet)
+
+    assert not device._response_event.is_set()
+    assert not device.statistics
+
+
+async def test_stale_statistics_response_is_ignored():
+    device = make_device()
+    device._expected_statistics_start = None
+    device._response_event = asyncio.Event()
+    device._device_status = hexlify(LOG_PACKET, " ")
+    device._event_trigger = no_event
+
+    await device._handle_data(None, LOG_PACKET)
+
+    assert not device._response_event.is_set()
+    assert not device.statistics
+
+
+async def test_monitor_packet_does_not_release_statistics_waiter():
+    device = make_device()
+    packet = bytes([0xD0, 0x02, 0x70])
+
+    device._expected_statistics_start = 100
+    device._response_event = asyncio.Event()
+    device._device_status = hexlify(packet, " ")
+    device._event_trigger = no_event
+
+    original_parser = device_module.parse_monitor_data
+    device_module.parse_monitor_data = lambda _value: None
+    try:
+        await device._handle_data(None, packet)
+    finally:
+        device_module.parse_monitor_data = original_parser
+
+    assert not device._response_event.is_set()
+
+
+class FakeClient:
+    is_connected = True
+
+    async def write_gatt_char(
+        self,
+        _characteristic,
+        _message,
+    ):
+        return None
+
+
+async def fake_connect():
+    return None
+
+
+async def test_timeout_clears_pending_response_state():
+    device = make_device()
+    device._client = FakeClient()
+    device._connect = fake_connect
+
+    original_wait_for = device_module.asyncio.wait_for
+
+    async def immediate_timeout(awaitable, timeout):
+        del timeout
+        close = getattr(awaitable, "close", None)
+        if close is not None:
+            close()
+        raise asyncio.TimeoutError
+
+    device_module.asyncio.wait_for = immediate_timeout
+    try:
+        result = await device.send_command(
+            statistics_message(),
+            retries=1,
+        )
+    finally:
+        device_module.asyncio.wait_for = original_wait_for
+
+    assert result is False
+    assert device._response_event is None
+    assert device._expected_statistics_start is None
+
+
+async def test_cancellation_clears_pending_response_state():
+    device = make_device()
+    device._client = FakeClient()
+    device._connect = fake_connect
+
+    task = asyncio.create_task(
+        device.send_command(
+            statistics_message(),
+            retries=1,
+        )
+    )
+
+    for _ in range(20):
+        if device._response_event is not None:
+            break
+        await asyncio.sleep(0)
+
+    assert device._response_event is not None
+
+    task.cancel()
+
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+    else:
+        raise AssertionError(
+            "send_command did not propagate cancellation"
+        )
+
+    assert device._response_event is None
+    assert device._expected_statistics_start is None
+
+
+async def test_failed_first_range_aborts_statistics_batch():
+    device = make_device()
+    calls = []
+
+    async def failed_statistics(start_index, count):
+        calls.append((start_index, count))
+        return False
+
+    device.get_statistics = failed_statistics
+
+    await device.update_statistics()
+
+    assert calls == [(100, 10)]
+
+
+async def run_tests():
+    await test_matching_statistics_response()
+    await test_wrong_statistics_start_is_ignored()
+    await test_short_statistics_response_is_ignored()
+    await test_stale_statistics_response_is_ignored()
+    await test_monitor_packet_does_not_release_statistics_waiter()
+    await test_timeout_clears_pending_response_state()
+    await test_cancellation_clears_pending_response_state()
+    await test_failed_first_range_aborts_statistics_batch()
+
+    print(
+        "[SUCCESS] BLE response correlation "
+        "regressions verified."
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(run_tests())

--- a/tests/test_response_correlation.py
+++ b/tests/test_response_correlation.py
@@ -32,6 +32,15 @@ LOG_PACKET = unhexlify(
 )
 
 
+SPARSE_111_PACKET = unhexlify(
+    "d041a20f006f000000110074000000c9"
+    "00c90000001f0bb800000c570bb90000"
+    "00980bba0000007c0bbb000000030bbc"
+    "000000230bbd000000230bbe00000089"
+    "1941"
+)
+
+
 def make_device():
     return DelongiPrimadonna(CONFIG, None)
 
@@ -74,6 +83,39 @@ async def test_wrong_statistics_start_is_ignored():
     assert not device._response_event.is_set()
     assert 100 not in device.statistics
     assert 105 not in device.statistics
+
+
+async def test_sparse_statistics_response_matches_111():
+    device = make_device()
+    device._expected_statistics_start = 111
+    device._response_event = asyncio.Event()
+    device._device_status = hexlify(SPARSE_111_PACKET, " ")
+    device._event_trigger = no_event
+
+    assert device._has_valid_crc(SPARSE_111_PACKET)
+
+    await device._process_raw_data(None, SPARSE_111_PACKET)
+
+    assert device._response_event.is_set()
+    assert device.statistics[111] == 17
+    assert device.statistics[116] == 201
+    assert device.statistics[3000] == 3159
+    assert device.statistics[3006] == 137
+
+
+async def test_sparse_statistics_response_does_not_match_110():
+    device = make_device()
+    device._expected_statistics_start = 110
+    device._response_event = asyncio.Event()
+    device._device_status = hexlify(SPARSE_111_PACKET, " ")
+    device._event_trigger = no_event
+
+    assert device._has_valid_crc(SPARSE_111_PACKET)
+
+    await device._process_raw_data(None, SPARSE_111_PACKET)
+
+    assert not device._response_event.is_set()
+    assert not device.statistics
 
 
 async def test_short_statistics_response_is_ignored():
@@ -142,12 +184,14 @@ class RespondingFakeClient:
     def __init__(self, device, response):
         self._device = device
         self._response = response
+        self.last_message = None
 
     async def write_gatt_char(
         self,
         _characteristic,
         _message,
     ):
+        self.last_message = bytes(_message)
         await self._device._handle_data(
             None,
             self._response,
@@ -175,6 +219,31 @@ async def test_matching_statistics_command_returns_true():
     assert result is True
     assert device.statistics[100] == 1288350
     assert device.statistics[105] == 15
+    assert device._response_event is None
+    assert device._expected_statistics_start is None
+
+
+async def test_matching_sparse_statistics_command_returns_true():
+    device = make_device()
+    device._device_status = hexlify(SPARSE_111_PACKET, " ")
+    client = RespondingFakeClient(
+        device,
+        SPARSE_111_PACKET,
+    )
+    device._client = client
+    device._connect = fake_connect
+
+    result = await device.send_command(
+        statistics_message(111),
+        retries=1,
+    )
+
+    assert result is True
+    assert client.last_message == unhexlify(
+        "0d08a20f006f0aff6d"
+    )
+    assert device.statistics[111] == 17
+    assert device.statistics[3000] == 3159
     assert device._response_event is None
     assert device._expected_statistics_start is None
 
@@ -285,17 +354,53 @@ async def test_failed_first_range_aborts_statistics_batch():
     assert calls == [(100, 10)]
 
 
+async def test_statistics_polling_starts_second_block_at_111():
+    device = make_device()
+    calls = []
+
+    async def successful_statistics(start_index, count):
+        calls.append((start_index, count))
+        return True
+
+    async def no_sleep(_delay):
+        return None
+
+    device.get_statistics = successful_statistics
+    device._last_stats_request = (
+        device_module.time.monotonic() - 61
+    )
+
+    original_sleep = device_module.asyncio.sleep
+    device_module.asyncio.sleep = no_sleep
+    try:
+        await device.update_statistics()
+    finally:
+        device_module.asyncio.sleep = original_sleep
+
+    assert calls == [
+        (100, 10),
+        (111, 10),
+        (3000, 10),
+        (3077, 4),
+        (3017, 10),
+    ]
+
+
 async def run_tests():
     await test_matching_statistics_response()
     await test_wrong_statistics_start_is_ignored()
+    await test_sparse_statistics_response_matches_111()
+    await test_sparse_statistics_response_does_not_match_110()
     await test_short_statistics_response_is_ignored()
     await test_stale_statistics_response_is_ignored()
     await test_monitor_packet_does_not_release_statistics_waiter()
     await test_matching_statistics_command_returns_true()
+    await test_matching_sparse_statistics_command_returns_true()
     await test_non_statistics_command_returns_true()
     await test_timeout_clears_pending_response_state()
     await test_cancellation_clears_pending_response_state()
     await test_failed_first_range_aborts_statistics_batch()
+    await test_statistics_polling_starts_second_block_at_111()
 
     print(
         "[SUCCESS] BLE response correlation "

--- a/tests/test_response_correlation.py
+++ b/tests/test_response_correlation.py
@@ -136,8 +136,76 @@ class FakeClient:
         return None
 
 
+class RespondingFakeClient:
+    is_connected = True
+
+    def __init__(self, device, response):
+        self._device = device
+        self._response = response
+
+    async def write_gatt_char(
+        self,
+        _characteristic,
+        _message,
+    ):
+        await self._device._handle_data(
+            None,
+            self._response,
+        )
+
+
 async def fake_connect():
     return None
+
+
+async def test_matching_statistics_command_returns_true():
+    device = make_device()
+    device._device_status = hexlify(LOG_PACKET, " ")
+    device._client = RespondingFakeClient(
+        device,
+        LOG_PACKET,
+    )
+    device._connect = fake_connect
+
+    result = await device.send_command(
+        statistics_message(),
+        retries=1,
+    )
+
+    assert result is True
+    assert device.statistics[100] == 1288350
+    assert device.statistics[105] == 15
+    assert device._response_event is None
+    assert device._expected_statistics_start is None
+
+
+async def test_non_statistics_command_returns_true():
+    device = make_device()
+    response = bytes([0xD0, 0x02, 0x84])
+    device._device_status = hexlify(response, " ")
+    device._client = RespondingFakeClient(
+        device,
+        response,
+    )
+    device._connect = fake_connect
+
+    result = await device.send_command(
+        [
+            0x0D,
+            0x07,
+            0x84,
+            0x0F,
+            0x02,
+            0x01,
+            0x00,
+            0x00,
+        ],
+        retries=1,
+    )
+
+    assert result is True
+    assert device._response_event is None
+    assert device._expected_statistics_start is None
 
 
 async def test_timeout_clears_pending_response_state():
@@ -223,6 +291,8 @@ async def run_tests():
     await test_short_statistics_response_is_ignored()
     await test_stale_statistics_response_is_ignored()
     await test_monitor_packet_does_not_release_statistics_waiter()
+    await test_matching_statistics_command_returns_true()
+    await test_non_statistics_command_returns_true()
     await test_timeout_clears_pending_response_state()
     await test_cancellation_clears_pending_response_state()
     await test_failed_first_range_aborts_statistics_batch()

--- a/tests/test_response_correlation.py
+++ b/tests/test_response_correlation.py
@@ -103,7 +103,7 @@ async def test_sparse_statistics_response_matches_111():
     assert device.statistics[3006] == 137
 
 
-async def test_sparse_statistics_response_does_not_match_110():
+async def test_sparse_statistics_response_advances_from_110_to_111():
     device = make_device()
     device._expected_statistics_start = 110
     device._response_event = asyncio.Event()
@@ -114,8 +114,34 @@ async def test_sparse_statistics_response_does_not_match_110():
 
     await device._process_raw_data(None, SPARSE_111_PACKET)
 
-    assert not device._response_event.is_set()
-    assert not device.statistics
+    assert device._response_event.is_set()
+    assert device.statistics[111] == 17
+    assert device.statistics[116] == 201
+
+
+async def test_sparse_statistics_response_advances_from_3077_to_23000():
+    device = make_device()
+    packet = bytes.fromhex(
+        "d0 1d a2 0f 59 d8 00 00 00 07 "
+        "59 d9 00 00 26 d0 "
+        "59 da 00 00 00 69 "
+        "59 db 00 00 01 92 "
+        "00 ce"
+    )
+    device._expected_statistics_start = 3077
+    device._response_event = asyncio.Event()
+    device._device_status = hexlify(packet, " ")
+    device._event_trigger = no_event
+
+    assert device._has_valid_crc(packet)
+
+    await device._process_raw_data(None, packet)
+
+    assert device._response_event.is_set()
+    assert device.statistics[23000] == 7
+    assert device.statistics[23001] == 9936
+    assert device.statistics[23003] == 402
+    assert 3077 not in device.statistics
 
 
 async def test_short_statistics_response_is_ignored():
@@ -381,8 +407,8 @@ async def test_statistics_polling_starts_second_block_at_111():
         (100, 10),
         (111, 10),
         (3000, 10),
-        (3077, 4),
         (3017, 10),
+        (3077, 4),
     ]
 
 
@@ -390,7 +416,8 @@ async def run_tests():
     await test_matching_statistics_response()
     await test_wrong_statistics_start_is_ignored()
     await test_sparse_statistics_response_matches_111()
-    await test_sparse_statistics_response_does_not_match_110()
+    await test_sparse_statistics_response_advances_from_110_to_111()
+    await test_sparse_statistics_response_advances_from_3077_to_23000()
     await test_short_statistics_response_is_ignored()
     await test_stale_statistics_response_is_ignored()
     await test_monitor_packet_does_not_release_statistics_waiter()

--- a/tests/test_stats_parser.py
+++ b/tests/test_stats_parser.py
@@ -15,7 +15,7 @@ async def test_parsing():
     # Packet from user's logs
     # d0 41 a2 0f 00 64 00 13 a8 9e 00 65 00 00 00 0a 00 69 00 00 00 0f 00 6a 00 23 65 e8 00 6c 00 00 00 00 00 6d 00 00 00 00 00 6f 00 00 00 12 00 74 00 00 02 84 02 84 00 00 00 00 0b b8 00 00 39 7e 54 d1
     log_packet = unhexlify("d041a20f00640013a89e00650000000a00690000000f006a002365e8006c00000000006d00000000006f000000120074000002840284000000000bb80000397e54d1")
-    await device._handle_data(None, log_packet)
+    await device._parse_statistics(log_packet)
 
     print(f"ID 100 (Implicit): {device.statistics.get(100)}")
     print(f"ID 101 (Explicit): {device.statistics.get(101)}")


### PR DESCRIPTION
## Summary

This PR fixes several BLE connection-lifecycle, statistics-polling, and receive-framing issues found during testing with a DeLonghi machine.

The changes were developed incrementally from hardware testing rather than as a general BLE rewrite. Initial testing exposed direct Bleak connection and cleanup problems, followed by unmanaged initialization and statistics work during reload and shutdown. Review then identified response-correlation and cross-connection receive-buffer issues. Finally, a DEBUG hardware capture reproduced an intermittent corrupted statistic as a CRC-invalid hybrid frame assembled when a partial response was retransmitted from its beginning.

The PR:

- uses `bleak-retry-connector` for BLE connection establishment and cleans up failed clients;
- tracks initialization, device-name, and statistics tasks so they can be cancelled during unload/removal;
- deduplicates and throttles statistics updates;
- uses Home Assistant background tasks for polling work that must not survive Core shutdown;
- correlates A2 statistics responses by treating the requested start as a lower bound, supporting sparse parameter ranges while rejecting responses that start below the active request;
- clears receive-buffer state when a new BLE connection starts;
- validates incoming frame CRCs before parsing and resynchronizes after an invalid frame candidate;
- adds regression coverage for connection cleanup, task lifecycle, response correlation, fragmentation, reconnect buffering, and RX resynchronization.

## RX framing issue

During hardware testing, an intermittent incorrect descaling counter was captured together with the raw A2 response.

A partial response was followed by retransmission from the beginning of the same frame. The existing reassembler combined both into a packet with a plausible start byte and length, so it reached the statistics parser even though its CRC was invalid.

In the captured case, bytes from the repeated frame header were interpreted as the value for statistics ID 105, resulting in `53313` (`0xD041`).

The fix validates complete frame candidates before parsing them. Invalid candidates are discarded while the buffer resynchronizes at the next possible frame start. No statistics-ID-specific workaround is used.

A regression test reproduces the observed `partial frame + restarted complete frame` sequence and verifies that the invalid hybrid candidate is rejected and exactly one valid frame is processed.

## Test plan

Compatibility/runtime checks:

| Home Assistant | Python | Result |
| --- | --- | --- |
| 2023.7.0 | 3.10 | integration import, BLE lifecycle, parser, compile and dependency checks passed |
| 2025.1.4 | 3.12 | integration import, BLE lifecycle, parser, compile and dependency checks passed |
| 2026.8.1 | 3.14 | full current regression suite passed; additionally hardware-tested |

The older environments used the Bluetooth dependency versions declared by those Home Assistant releases.

Additional checks included:

- `compileall`
- `flake8`
- `git diff --check`
- BLE lifecycle regression tests
- statistics response-correlation tests
- statistics parser tests
- standalone parser tests
- `pip check`
- import ordering checks on the files changed by the lifecycle/BLE work

Hardware verification was performed with Home Assistant Core 2026.8.1 and a DeLonghi Dinamica Plus ECAM 370.95.

Verified on hardware:

- integration loads normally after a full Home Assistant restart;
- config-entry unload/reload completes cleanly;
- BLE disconnect/reconnect works after reload;
- DeLonghi polling tasks no longer remain after Home Assistant's final-writes shutdown stage;
- valid statistics packets still pass the CRC check and update entities normally;
- a fresh descaling count of `3` was received after deploying the CRC validation;
- the malformed-frame pattern is covered by a regression test derived from the captured hardware failure;
- statistics polling completed in monotonic order `100 → 111 → 3000 → 3017 → 3077`;
- the `3077/count 4` request reproducibly returned a CRC-valid sparse response starting at parameter `23000`; the lower-bound correlation accepted and parsed IDs `23000..23003` without an unexpected-response rejection or subsequent 10-second timeout.

Intermittent command timeouts, GATT `UNLIKELY_ERROR`, and host Bluetooth controller connection-slot failures were also observed during testing. They are not proven to share the same root cause and are intentionally outside the scope of this PR.

## Summary by Sourcery

Improve BLE connection lifecycle, statistics polling management, and RX frame handling for the Delonghi Primadonna integration, with added regression tests for connection, buffering, and response correlation behavior.

New Features:
- Introduce managed background tasks for device initialization and periodic statistics updates that can be cancelled on unload

Bug Fixes:
- Ensure BLE connections are established via a retrying connector and are properly cleaned up on failures and cancellations
- Reset receive-buffer state on new BLE connections and validate CRCs to avoid processing malformed or hybrid BLE frames
- Correlate A2 statistics responses using the requested start as a lower bound so sparse responses are accepted while responses starting below the active request are ignored

Enhancements:
- Throttle statistics refreshes and batch abort on early failures to reduce unnecessary BLE traffic
- Refine command send behavior to report success/failure and improve error handling around timeouts and BLE write errors

Tests:
- Add BLE lifecycle regression tests covering connection, buffering, write failures, and task cancellation
- Add response-correlation regression tests covering statistics request/response matching, timeouts, and batch abort behavior