### PR TITLE
Correct minimum Home Assistant version

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
   "name": "DeLonghi BLE",
   "render_readme": true,
-  "homeassistant": "2023.1.1",
+  "homeassistant": "2023.7.0",
   "hide_default_branch": true
 }


### PR DESCRIPTION
## Summary

Correct the stale minimum Home Assistant version declared in `hacs.json`.

The integration currently declares Home Assistant `2023.1.1`, but the existing upstream code already depends on APIs that are unavailable in that release:

- `EntityCategory` from `homeassistant.const` rules out Home Assistant 2023.1 and 2023.2.
- Existing `Platform.IMAGE` usage is unavailable through Home Assistant 2023.6 and is present in 2023.7.

Home Assistant 2023.7.0 was also directly verified during compatibility testing as satisfying the integration's existing API usage and allowing the integration to import successfully.

This is a metadata correction for the current upstream codebase and is independent of the BLE lifecycle changes in PR #245.

## Change

```diff
-  "homeassistant": "2023.1.1",
+  "homeassistant": "2023.7.0",
```

No integration code is changed.

## Summary by Sourcery

Bug Fixes:
- Correct the declared minimum Home Assistant version in hacs.json to match the integration's existing API requirements.