### PR TITLE
Pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
           run: |
               echo ::set-output name=version::$(cat custom_components/delonghi_primadonna/manifest.json | jq -r '.version')
         - name: Create Release
-          uses: marvinpinto/action-automatic-releases@latest
+          uses: marvinpinto/action-automatic-releases@d68defdd11f9dcc7f52f35c1b7c236ee7513bcc1 # latest
           with:
               repo_token: ${{ secrets.GITHUB_TOKEN }}
               title: ${{ github.ref == 'refs/heads/develop' && 'Test release' || 'Release' }} ${{ steps.get_version.outputs.version }}${{ github.ref == 'refs/heads/develop' && '-beta' || '' }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,12 +10,12 @@ jobs:
     steps:
       - uses: "actions/checkout@v7"
       
-      - uses: "hacs/action@main"
+      - uses: "hacs/action@1ebf01c408f29afcb6406bd431bc98fd8cbb15aa" # main
         name: HACS validation
         with:
           category: "integration"
 
-      - uses: "home-assistant/actions/hassfest@master"
+      - uses: "home-assistant/actions/hassfest@a7c616ce81ccda50150bf1595786c71b1883fabb" # master
           
   lint:
     name: Lint
@@ -31,7 +31,7 @@ jobs:
         run: pip install -r requirements_dev.txt
 
       - name: Flake8 lint
-        uses: TrueBrain/actions-flake8@v2
+        uses: TrueBrain/actions-flake8@36ab8db923b9a63cfd4b87840ca2f94c117bb50e # v2
         with:
           path: custom_components
 


### PR DESCRIPTION
## Summary

Pin third-party GitHub Actions used by the release and validation workflows to full commit SHAs.

This reduces the supply-chain risk from mutable tags and branches while keeping the currently referenced action revisions unchanged.

## Changes

- Pin `marvinpinto/action-automatic-releases@latest`
- Pin `hacs/action@main`
- Pin `home-assistant/actions/hassfest@master`
- Pin `TrueBrain/actions-flake8@v2`

The pinned SHAs correspond to the revisions currently referenced by those tags/branches. Inline comments retain the original refs for easier future maintenance and Dependabot updates.

## Scope

No application code or workflow behavior is intentionally changed.

## Summary by Sourcery

Pin third-party GitHub Actions in validation and release workflows to fixed commit SHAs to reduce supply-chain risk from mutable tags.

CI:
- Update validation workflow to use commit-SHA pins for HACS validation, hassfest, and Flake8 GitHub Actions.
- Update release workflow to pin the automatic releases GitHub Action to a specific commit SHA.