### PR TITLE
fix: handle BleakError gracefully when reading device name characteristic

### DIFF
--- a/custom_components/delonghi_primadonna/const.py
+++ b/custom_components/delonghi_primadonna/const.py
@@ -3,6 +3,8 @@ from homeassistant.const import EntityCategory
 
 DOMAIN = 'delonghi_primadonna'
 
+DEFAULT_DEVICE_NAME = 'DeLonghi PrimaDonna'
+
 BEVERAGE_NONE = 'none'
 
 SERVICE = '00035b03-58e6-07dd-021a-08123a000300'

--- a/custom_components/delonghi_primadonna/device.py
+++ b/custom_components/delonghi_primadonna/device.py
@@ -712,7 +712,6 @@ class DelongiPrimadonna:
         async with self._lock:
             try:
                 await self._connect()
-                self.hostname = ''
                 try:
                     self.hostname = bytes(
                         await self._client.read_gatt_char(
@@ -720,7 +719,7 @@ class DelongiPrimadonna:
                         )
                     ).decode('utf-8')
                 except BleakError as error:
-                    _LOGGER.info('Could not read NAME_CHARACTERISTIC: %s', error)
+                    _LOGGER.debug('Could not read NAME_CHARACTERISTIC: %s', error)
                     self.hostname = self.name or DEFAULT_DEVICE_NAME
                 await self._client.write_gatt_char(
                     uuid.UUID(CONTROLL_CHARACTERISTIC), bytearray(DEBUG)

--- a/custom_components/delonghi_primadonna/device.py
+++ b/custom_components/delonghi_primadonna/device.py
@@ -30,7 +30,7 @@ from .const import (AMERICANO_OFF, AMERICANO_ON, AVAILABLE_PROFILES,
                     COFFEE_GROUNDS_CONTAINER_CLEAN,
                     COFFEE_GROUNDS_CONTAINER_DETACHED,
                     COFFEE_GROUNDS_CONTAINER_FULL, CONTROLL_CHARACTERISTIC,
-                    DEBUG, DEFAULT_IMAGE_URL, DEVICE_READY, DEVICE_STATUS,
+                    DEBUG, DEFAULT_DEVICE_NAME, DEFAULT_IMAGE_URL, DEVICE_READY, DEVICE_STATUS,
                     DEVICE_TURNOFF, DOMAIN, DOPPIO_OFF, DOPPIO_ON,
                     ESPRESSO2_OFF, ESPRESSO2_ON, ESPRESSO_OFF, ESPRESSO_ON,
                     HOTWATER_OFF, HOTWATER_ON, LONG_OFF, LONG_ON,
@@ -720,8 +720,8 @@ class DelongiPrimadonna:
                         )
                     ).decode('utf-8')
                 except BleakError as error:
-                    _LOGGER.debug('Could not read NAME_CHARACTERISTIC: %s', error)
-                    self.hostname = self.name or "DeLonghi PrimaDonna"
+                    _LOGGER.info('Could not read NAME_CHARACTERISTIC: %s', error)
+                    self.hostname = self.name or DEFAULT_DEVICE_NAME
                 await self._client.write_gatt_char(
                     uuid.UUID(CONTROLL_CHARACTERISTIC), bytearray(DEBUG)
                 )

--- a/custom_components/delonghi_primadonna/device.py
+++ b/custom_components/delonghi_primadonna/device.py
@@ -712,11 +712,16 @@ class DelongiPrimadonna:
         async with self._lock:
             try:
                 await self._connect()
-                self.hostname = bytes(
-                    await self._client.read_gatt_char(
-                        uuid.UUID(NAME_CHARACTERISTIC)
-                    )
-                ).decode('utf-8')
+                try:
+                    self.hostname = bytes(
+                        await self._client.read_gatt_char(
+                            uuid.UUID(NAME_CHARACTERISTIC)
+                        )
+                    ).decode('utf-8')
+                except (BleakError, Exception) as error:
+                    _LOGGER.info('Could not read NAME_CHARACTERISTIC: %s', error)
+                    if not self.hostname:
+                        self.hostname = self.name or "DeLonghi PrimaDonna"
                 await self._client.write_gatt_char(
                     uuid.UUID(CONTROLL_CHARACTERISTIC), bytearray(DEBUG)
                 )

--- a/custom_components/delonghi_primadonna/device.py
+++ b/custom_components/delonghi_primadonna/device.py
@@ -712,16 +712,16 @@ class DelongiPrimadonna:
         async with self._lock:
             try:
                 await self._connect()
+                self.hostname = ''
                 try:
                     self.hostname = bytes(
                         await self._client.read_gatt_char(
                             uuid.UUID(NAME_CHARACTERISTIC)
                         )
                     ).decode('utf-8')
-                except (BleakError, Exception) as error:
-                    _LOGGER.info('Could not read NAME_CHARACTERISTIC: %s', error)
-                    if not self.hostname:
-                        self.hostname = self.name or "DeLonghi PrimaDonna"
+                except BleakError as error:
+                    _LOGGER.debug('Could not read NAME_CHARACTERISTIC: %s', error)
+                    self.hostname = self.name or "DeLonghi PrimaDonna"
                 await self._client.write_gatt_char(
                     uuid.UUID(CONTROLL_CHARACTERISTIC), bytearray(DEBUG)
                 )


### PR DESCRIPTION
On some Bluetooth adapters, operating systems, or specific models of the DeLonghi PrimaDonna, the standard GATT Device Name characteristic
      (`00002A00-0000-1000-8000-00805F9B34FB`) is either not readable, not exposed, or blocked by the host controller.

 Currently, if `read_gatt_char` throws a `BleakError` while attempting to read this characteristic in `get_device_name()`, the exception is caught
      by the outer block which sets `self.connected = False`. This results in the integration constantly flagging itself as disconnected and looping setup
      attempts, despite successfully connecting and being able to write to the control characteristic.

### Solution
This PR wraps the standard GATT name retrieval in a localized `try/except` block. If reading the name fails:
1. It logs an info message.
2. It falls back to the configured device name (`self.name`) or a default string so `self.hostname` is populated.
3. It then continues and successfully writes the initialization commands and marks `self.connected = True`.

## Summary by Sourcery

Handle failures when reading the Bluetooth GATT device name without marking the device as disconnected.

Bug Fixes:
- Prevent BleakError raised during NAME_CHARACTERISTIC reads from causing the integration to report the device as disconnected and loop reconnection attempts.

Enhancements:
- Fall back to a configured or default device name when the GATT device name characteristic is unreadable.
- Add a constant for a default DeLonghi PrimaDonna device name used when the Bluetooth name cannot be read.