### PR TITLE
Guard against corrupt BLE profile names

### DIFF
--- a/custom_components/delonghi_primadonna/const.py
+++ b/custom_components/delonghi_primadonna/const.py
@@ -23,12 +23,14 @@ DEFAULT_IMAGE_URL = (
 BEVERAGE_SERVICE_NAME = 'make_beverage'
 
 # Mapping of profile id to profile name
-AVAILABLE_PROFILES = {
+DEFAULT_PROFILES = {
     1: 'Profile 1',
     2: 'Profile 2',
     3: 'Profile 3',
     4: 'Guest',
 }
+
+AVAILABLE_PROFILES = dict(DEFAULT_PROFILES)
 
 POWER_OFF_OPTIONS = {
     '15min': 0,

--- a/custom_components/delonghi_primadonna/device.py
+++ b/custom_components/delonghi_primadonna/device.py
@@ -31,12 +31,13 @@ from .const import (AMERICANO_OFF, AMERICANO_ON, AVAILABLE_PROFILES,
                     COFFEE_GROUNDS_CONTAINER_DETACHED,
                     COFFEE_GROUNDS_CONTAINER_FULL, CONTROLL_CHARACTERISTIC,
                     DEBUG, DEFAULT_DEVICE_NAME, DEFAULT_IMAGE_URL,
-                    DEVICE_READY, DEVICE_STATUS, DEVICE_TURNOFF, DOMAIN,
-                    DOPPIO_OFF, DOPPIO_ON, ESPRESSO2_OFF, ESPRESSO2_ON,
-                    ESPRESSO_OFF, ESPRESSO_ON, HOTWATER_OFF, HOTWATER_ON,
-                    LONG_OFF, LONG_ON, MACHINE_STATUS, NAME_CHARACTERISTIC,
-                    NOZZLE_STATE, START_COFFEE, STEAM_OFF, STEAM_ON,
-                    WATER_SHORTAGE, WATER_TANK_DETACHED)
+                    DEFAULT_PROFILES, DEVICE_READY, DEVICE_STATUS,
+                    DEVICE_TURNOFF, DOMAIN, DOPPIO_OFF, DOPPIO_ON,
+                    ESPRESSO2_OFF, ESPRESSO2_ON, ESPRESSO_OFF, ESPRESSO_ON,
+                    HOTWATER_OFF, HOTWATER_ON, LONG_OFF, LONG_ON,
+                    MACHINE_STATUS, NAME_CHARACTERISTIC, NOZZLE_STATE,
+                    START_COFFEE, STEAM_OFF, STEAM_ON, WATER_SHORTAGE,
+                    WATER_TANK_DETACHED)
 from .machine_switch import MachineSwitch, parse_switches
 from .model import get_machine_model
 
@@ -310,14 +311,22 @@ class DelongiPrimadonna:
         self._n_profiles = (
             machine.nProfiles
             if machine and machine.nProfiles
-            else len(AVAILABLE_PROFILES)
+            else len(DEFAULT_PROFILES)
         )
+        # Per-device defaults so each instance keeps its own profile
+        # mapping even when multiple machines are configured.
+        self._default_profiles: dict[int, str] = {
+            pid: DEFAULT_PROFILES.get(pid, f"Profile {pid}")
+            for pid in range(1, self._n_profiles + 1)
+        }
+        # Start from clean defaults so stale / corrupt values from a
+        # previous session cannot leak into a fresh load.
+        AVAILABLE_PROFILES.clear()
+        AVAILABLE_PROFILES.update(self._default_profiles)
         self.active_profile_id: int | None = None
-        for pid in range(1, self._n_profiles + 1):
-            AVAILABLE_PROFILES.setdefault(pid, f"Profile {pid}")
-        for pid in list(AVAILABLE_PROFILES):
-            if pid > self._n_profiles:
-                AVAILABLE_PROFILES.pop(pid)
+        self._profile_ids: dict[str, int] = {
+            name: pid for pid, name in AVAILABLE_PROFILES.items()
+        }
         self.profiles = list(AVAILABLE_PROFILES.values())
         self._profiles_loaded = False
 
@@ -524,15 +533,23 @@ class DelongiPrimadonna:
             if monitor_data:
                 self._handle_monitor_data(monitor_data, answer_id, value)
         elif answer_id == 0xA4:
-            parsed = []
+            parsed = {}
             try:
                 parsed = self._parse_profile_response(
                     list(value)
                 )
             except Exception as err:  # noqa: BLE001
                 _LOGGER.warning("Failed to parse profile response: %s", err)
-            for pid, name in parsed.items():
-                AVAILABLE_PROFILES[pid] = name
+            if parsed:
+                AVAILABLE_PROFILES.update(parsed)
+            else:
+                # Reset to per-device defaults when parsing returned
+                # nothing useful (corrupt data or decode failure).
+                AVAILABLE_PROFILES.clear()
+                AVAILABLE_PROFILES.update(self._default_profiles)
+            self._profile_ids = {
+                name: pid for pid, name in AVAILABLE_PROFILES.items()
+            }
             _LOGGER.debug(
                 "Available profiles: %s",
                 AVAILABLE_PROFILES
@@ -598,11 +615,46 @@ class DelongiPrimadonna:
         if answer_id == 0x75:
             self.active_switches = parse_switches(raw_packet)
 
+    @staticmethod
+    def _is_valid_profile_name(name: str) -> bool:
+        """Return True if *name* looks like a real profile name.
+
+        Profile names on DeLonghi machines use Latin characters only
+        (ASCII, accented letters for European languages).  Misaligned
+        UTF-16-BE decoding produces printable CJK or other non-Latin
+        characters — this check rejects those.
+        """
+        if not name:
+            return False
+        for ch in name:
+            # Reject null bytes and control characters
+            if ch == "\x00" or (ord(ch) < 0x20 and ch not in "\t\n\r"):
+                return False
+            cp = ord(ch)
+            # Reject CJK Unified Ideographs (U+4E00..U+9FFF)
+            if 0x4E00 <= cp <= 0x9FFF:
+                return False
+            # Reject Hangul Syllables (U+AC00..U+D7AF)
+            if 0xAC00 <= cp <= 0xD7AF:
+                return False
+            # Reject Katakana (U+30A0..U+30FF) — common in misaligned decode
+            if 0x30A0 <= cp <= 0x30FF:
+                return False
+            # Reject Hiragana (U+3040..U+309F)
+            if 0x3040 <= cp <= 0x309F:
+                return False
+        return True
+
     def _parse_profile_response(
         self,
         data: list[int],
     ) -> dict[int, str]:
-        """Parse profile names sent by the machine."""
+        """Parse profile names sent by the machine.
+
+        Returns a ``{id: name}`` dict.  When the decoded names look
+        corrupt (null bytes, unprintable characters) an empty dict is
+        returned so the caller keeps the hardcoded defaults.
+        """
 
         b = bytes(data)
         if len(b) < 4 or b[0] != 0xD0:
@@ -615,15 +667,28 @@ class DelongiPrimadonna:
         profile_index = 1
         idx = NAME_HEADER
         while idx + NAME_SIZE < len(b):
-            profiles.setdefault(
-                profile_index,
-                b[idx:idx + NAME_SIZE]
-                .decode("utf-16-be")
-                .rstrip("\x00")
-                .strip(),
-            )
+            raw = b[idx:idx + NAME_SIZE]
+            try:
+                name = raw.decode("utf-16-be").rstrip("\x00").strip()
+            except UnicodeDecodeError:
+                _LOGGER.debug(
+                    "Profile name decode failed for bytes %s",
+                    hexlify(raw, " "),
+                )
+                return {}
+            profiles.setdefault(profile_index, name)
             profile_index += 1
             idx += NAME_SIZE + NAME_OFFSET
+
+        # If *any* decoded name looks corrupt, discard the whole batch
+        # so the hardcoded defaults in AVAILABLE_PROFILES stay in use.
+        for pid, name in profiles.items():
+            if not self._is_valid_profile_name(name):
+                _LOGGER.debug(
+                    "Discarding corrupt profile %d: %r", pid, name
+                )
+                return {}
+
         return profiles
 
     async def power_on(self) -> None:

--- a/custom_components/delonghi_primadonna/select.py
+++ b/custom_components/delonghi_primadonna/select.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from .base_entity import DelonghiDeviceEntity
-from .const import AVAILABLE_PROFILES, BEVERAGE_NONE, DOMAIN, POWER_OFF_OPTIONS
+from .const import BEVERAGE_NONE, DOMAIN, POWER_OFF_OPTIONS
 from .device import BeverageEntityFeature, DelongiPrimadonna
 
 _LOGGER = logging.getLogger(__name__)
@@ -62,8 +62,10 @@ class ProfileSelect(DelonghiDeviceEntity, SelectEntity, RestoreEntity):
     def current_option(self) -> str | None:
         """Return the currently active profile from the device."""
         pid = self.device.active_profile_id
-        if pid is not None and pid in AVAILABLE_PROFILES:
-            return AVAILABLE_PROFILES[pid]
+        if pid is not None:
+            for name, id_ in self.device._profile_ids.items():
+                if id_ == pid:
+                    return name
         return self._attr_current_option
 
     @property
@@ -73,14 +75,7 @@ class ProfileSelect(DelonghiDeviceEntity, SelectEntity, RestoreEntity):
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
-        profile_id = next(
-            (
-                pid
-                for pid, name in AVAILABLE_PROFILES.items()
-                if name == option
-            ),
-            None,
-        )
+        profile_id = self.device._profile_ids.get(option)
         _LOGGER.debug("Select profile '%s' id=%s", option, profile_id)
         self.hass.async_create_task(self.device.select_profile(profile_id))
         self._attr_current_option = option


### PR DESCRIPTION
_parse_profile_response decodes profile names as UTF-16-BE, but on some models (e.g. Dinamica PLUS ECAM 370.95.S) the raw bytes contain null-padded or misaligned data that decodes to garbage (null bytes, CJK characters, etc.).

When this happens the corrupt names overwrite the hardcoded defaults (Profile 1..3, Guest) in AVAILABLE_PROFILES, breaking the dashboard and the profile select entity.

Changes:
- Add DEFAULT_PROFILES constant in const.py so the hardcoded defaults can be restored without duplicating the dict literal.
- Reset AVAILABLE_PROFILES to DEFAULT_PROFILES at device init so stale values from a previous session cannot leak.
- Catch UnicodeDecodeError in _parse_profile_response and return an empty dict on failure.
- Validate every decoded name with _is_valid_profile_name(); if any name contains null bytes or non-printable characters the whole batch is discarded and the hardcoded defaults are kept.
- In the 0xA4 handler, only update AVAILABLE_PROFILES when the parsed dict is non-empty; otherwise reset to defaults.

Tested on DeLonghi Dinamica PLUS ECAM 370.95.S — profile select now shows clean names ("Koky", "PROFIL 2", …) instead of garbled text.

## Summary by Sourcery

Protect BLE profile handling by validating received names and falling back to clean per-device defaults when the response is corrupt.

Bug Fixes:
- Prevent corrupt or undecodable BLE profile names from replacing the machine’s default profile names.
- Restore per-device default profiles when profile data is invalid or unavailable.
- Keep profile selection state and option lookup synchronized with each device’s validated profile mapping.

Enhancements:
- Centralize default profile definitions and isolate profile mappings between configured devices.