### PR TITLE
Add a standby switch, limited to models where the command is verified

### DIFF
--- a/custom_components/delonghi_primadonna/const.py
+++ b/custom_components/delonghi_primadonna/const.py
@@ -111,6 +111,16 @@ Command bytes
 """
 BYTES_POWER = [0x0d, 0x07, 0x84, 0x0f, 0x02, 0x01, 0x55, 0x12]
 
+# AppControl (0x84) with (1, 1) puts the machine into standby. This is not
+# part of the observed app traffic; it was found by probing and confirmed on
+# the machines listed below. The switch is only offered for those, because
+# what (1, 1) does on an untested model is unknown.
+BYTES_POWER_OFF = [0x0d, 0x07, 0x84, 0x0f, 0x01, 0x01, 0x00, 0x00]
+
+# Product codes on which standby has actually been exercised.
+# PrimaDonna ELITE 656.55 ships under two codes; both are the same machine.
+STANDBY_VERIFIED_PRODUCT_CODES = ('0132217031', '0132217027')
+
 # Default bitmask for commands
 BASE_COMMAND = '10000001'
 

--- a/custom_components/delonghi_primadonna/device.py
+++ b/custom_components/delonghi_primadonna/device.py
@@ -23,9 +23,9 @@ from homeassistant.core import HomeAssistant
 
 from .const import (AMERICANO_OFF, AMERICANO_ON, AVAILABLE_PROFILES,
                     BASE_COMMAND, BEVERAGE_NONE, BYTES_AUTOPOWEROFF_COMMAND,
-                    BYTES_LOAD_PROFILES, BYTES_POWER, BYTES_STATISTICS_COMMAND,
-                    BYTES_SWITCH_COMMAND, BYTES_TIME_COMMAND,
-                    BYTES_WATER_HARDNESS_COMMAND,
+                    BYTES_LOAD_PROFILES, BYTES_POWER, BYTES_POWER_OFF,
+                    BYTES_STATISTICS_COMMAND, BYTES_SWITCH_COMMAND,
+                    BYTES_TIME_COMMAND, BYTES_WATER_HARDNESS_COMMAND,
                     BYTES_WATER_TEMPERATURE_COMMAND, COFFE_OFF, COFFE_ON,
                     COFFEE_GROUNDS_CONTAINER_CLEAN,
                     COFFEE_GROUNDS_CONTAINER_DETACHED,
@@ -629,6 +629,10 @@ class DelongiPrimadonna:
     async def power_on(self) -> None:
         """Turn the device on."""
         await self.send_command(BYTES_POWER)
+
+    async def power_off(self) -> None:
+        """Put the device into standby."""
+        await self.send_command(BYTES_POWER_OFF)
 
     async def cup_light_on(self) -> None:
         """Turn the cup light on."""

--- a/custom_components/delonghi_primadonna/strings.json
+++ b/custom_components/delonghi_primadonna/strings.json
@@ -51,6 +51,9 @@
             "energy_save_mode": {
                 "name": "Energy save mode"
             },
+            "power": {
+                "name": "Power"
+            },
             "sounds": {
                 "name": "Sounds"
             },

--- a/custom_components/delonghi_primadonna/switch.py
+++ b/custom_components/delonghi_primadonna/switch.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from .base_entity import DelonghiDeviceEntity
-from .const import DOMAIN
+from .const import DOMAIN, STANDBY_VERIFIED_PRODUCT_CODES
 from .device import DelongiPrimadonna
 from .model import get_machine_model
 
@@ -31,6 +31,11 @@ async def async_setup_entry(
         DelongiPrimadonnaPowerSaveSwitch(delongh_device, hass),
         DelongiPrimadonnaSoundsSwitch(delongh_device, hass),
     ]
+
+    if delongh_device.product_code in STANDBY_VERIFIED_PRODUCT_CODES:
+        switches.append(
+            DelongiPrimadonnaPowerSwitch(delongh_device, hass),
+        )
 
     if model and model.cup_light_settings:
         switches.insert(
@@ -199,3 +204,28 @@ class DelongiPrimadonnaTimeSyncSwitch(
         """Turn the sounds off."""
         self.device.sync_time = False
         self._attr_is_on = False
+
+
+class DelongiPrimadonnaPowerSwitch(DelonghiDeviceEntity, ToggleEntity):
+    """Turn the machine on, or put it into standby.
+
+    Only offered on the models listed in STANDBY_VERIFIED_PRODUCT_CODES.
+    The state follows the machine status from the monitor packets, so it
+    also reflects use of the physical power button.
+    """
+
+    _attr_icon = 'mdi:power'
+    _attr_translation_key = 'power'
+
+    @property
+    def is_on(self) -> bool:
+        """Return True while the machine is not in standby."""
+        return self.device.switches.is_on
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the machine on."""
+        self.hass.async_create_task(self.device.power_on())
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Put the machine into standby."""
+        self.hass.async_create_task(self.device.power_off())

--- a/custom_components/delonghi_primadonna/translations/de.json
+++ b/custom_components/delonghi_primadonna/translations/de.json
@@ -56,6 +56,9 @@
       },
       "time_sync": {
         "name": "Zeitsynchronisation"
+      },
+      "power": {
+        "name": "Ein/Aus"
       }
     },
     "binary_sensor": {

--- a/custom_components/delonghi_primadonna/translations/en.json
+++ b/custom_components/delonghi_primadonna/translations/en.json
@@ -56,6 +56,9 @@
       },
       "time_sync": {
         "name": "Time sync"
+      },
+      "power": {
+        "name": "Power"
       }
     },
     "binary_sensor": {

--- a/custom_components/delonghi_primadonna/translations/fr.json
+++ b/custom_components/delonghi_primadonna/translations/fr.json
@@ -56,6 +56,9 @@
       },
       "time_sync": {
         "name": "Synchronisation de l'heure"
+      },
+      "power": {
+        "name": "Power"
       }
     },
     "binary_sensor": {

--- a/custom_components/delonghi_primadonna/translations/hu.json
+++ b/custom_components/delonghi_primadonna/translations/hu.json
@@ -56,6 +56,9 @@
       },
       "time_sync": {
         "name": "Idő szinkronizálása"
+      },
+      "power": {
+        "name": "Power"
       }
     },
     "binary_sensor": {

--- a/custom_components/delonghi_primadonna/translations/it.json
+++ b/custom_components/delonghi_primadonna/translations/it.json
@@ -56,6 +56,9 @@
       },
       "time_sync": {
         "name": "Sincro ora"
+      },
+      "power": {
+        "name": "Power"
       }
     },
     "binary_sensor": {

--- a/custom_components/delonghi_primadonna/translations/ja.json
+++ b/custom_components/delonghi_primadonna/translations/ja.json
@@ -56,6 +56,9 @@
       },
       "time_sync": {
         "name": "時刻同期"
+      },
+      "power": {
+        "name": "Power"
       }
     },
     "binary_sensor": {

--- a/custom_components/delonghi_primadonna/translations/ko.json
+++ b/custom_components/delonghi_primadonna/translations/ko.json
@@ -56,6 +56,9 @@
       },
       "time_sync": {
         "name": "時間 동기화"
+      },
+      "power": {
+        "name": "Power"
       }
     },
     "binary_sensor": {

--- a/custom_components/delonghi_primadonna/translations/pl.json
+++ b/custom_components/delonghi_primadonna/translations/pl.json
@@ -56,6 +56,9 @@
       },
       "time_sync": {
         "name": "Synchronizacja czasu"
+      },
+      "power": {
+        "name": "Power"
       }
     },
     "binary_sensor": {

--- a/custom_components/delonghi_primadonna/translations/ro.json
+++ b/custom_components/delonghi_primadonna/translations/ro.json
@@ -56,6 +56,9 @@
       },
       "time_sync": {
         "name": "Sincronizare oră"
+      },
+      "power": {
+        "name": "Power"
       }
     },
     "binary_sensor": {

--- a/custom_components/delonghi_primadonna/translations/ru.json
+++ b/custom_components/delonghi_primadonna/translations/ru.json
@@ -56,6 +56,9 @@
       },
       "time_sync": {
         "name": "Синхронизация времени"
+      },
+      "power": {
+        "name": "Power"
       }
     },
     "binary_sensor": {

--- a/custom_components/delonghi_primadonna/translations/sk.json
+++ b/custom_components/delonghi_primadonna/translations/sk.json
@@ -56,6 +56,9 @@
       },
       "time_sync": {
         "name": "Synchronizácia času"
+      },
+      "power": {
+        "name": "Power"
       }
     },
     "binary_sensor": {

--- a/custom_components/delonghi_primadonna/translations/zh-Hans.json
+++ b/custom_components/delonghi_primadonna/translations/zh-Hans.json
@@ -56,6 +56,9 @@
       },
       "time_sync": {
         "name": "时间同步"
+      },
+      "power": {
+        "name": "Power"
       }
     },
     "binary_sensor": {


### PR DESCRIPTION
Split out of #251 as you asked.

`AppControl` `0x84` with `(1, 1)` puts the machine into standby — the counterpart to the existing `BYTES_POWER`. You were right to be wary: it was found by probing, not observed in app traffic, and I have only exercised it on one machine.

So rather than shipping it everywhere and hoping, the entity is gated on the product code:

```python
STANDBY_VERIFIED_PRODUCT_CODES = ('0132217031', '0132217027')
```

Those are the two SKUs of the PrimaDonna ELITE 656.55. On anything else the switch is simply not created, so a Dinamica or a Maestosa never sees the command. This follows the same shape as the existing `if model and model.cup_light_settings:` gate, and widening the tuple is a one-line change once someone reports back.

I went with a model gate rather than "disabled by default" because it removes the risk instead of moving it to the user — but say the word and I will add `_attr_entity_registry_enabled_default = False` on top.

Evidence: on the 656.55, `0d 07 84 0f 01 01 00 00` puts the machine into standby and the monitor packets report it; `is_on` follows them, so the switch also tracks the physical power button.

Rebased on master (1.17.19). `flake8` and `isort` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZJvU4uvEcpxdxVSBKyudM

## Summary by Sourcery

Add a model-gated power switch for safely controlling standby on verified De’Longhi machines.

New Features:
- Add a power switch that turns verified machines on and puts them into standby.
- Expose the standby switch only for the verified PrimaDonna ELITE 656.55 product codes.
- Add localized names and translations for the new power switch.

Enhancements:
- Keep the switch state synchronized with reported machine power status, including use of the physical power button.