### PR TITLE
Make the time sync switch actually synchronise

### DIFF
--- a/custom_components/delonghi_primadonna/device.py
+++ b/custom_components/delonghi_primadonna/device.py
@@ -292,6 +292,7 @@ class DelongiPrimadonna:
         self.switches = DeviceSwitches()
         self.active_switches: list[MachineSwitch] = []
         self.sync_time = False
+        self.last_time_sync = 0.0
         self._lock = asyncio.Lock()
         self._rx_buffer = bytearray()
         self._response_event = None

--- a/custom_components/delonghi_primadonna/switch.py
+++ b/custom_components/delonghi_primadonna/switch.py
@@ -1,6 +1,7 @@
 """Switch entities for Delonghi Primadonna."""
 
 import datetime
+import time
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
@@ -174,28 +175,49 @@ class DelongiPrimadonnaSoundsSwitch(
 class DelongiPrimadonnaTimeSyncSwitch(
         DelonghiDeviceEntity, ToggleEntity, RestoreEntity
 ):
-    _attr_is_on = False
+    """Keep the machine clock in step with Home Assistant.
+
+    While on, the clock is set right away and then re-synced once a day.
+    """
+
     _attr_icon = 'mdi:clock-time-eight-outline'
     _attr_translation_key = 'time_sync'
 
     async def async_added_to_hass(self) -> None:
         await super().async_added_to_hass()
         if (last_state := await self.async_get_last_state()) is not None:
-            self._attr_is_on = last_state.state == 'on'
+            self.device.sync_time = last_state.state == 'on'
+
+    @property
+    def is_on(self) -> bool:
+        """Return whether time synchronization is enabled."""
+        return self.device.sync_time
 
     @property
     def entity_category(self, **kwargs: Any) -> None:
         """Return the category of the entity."""
         return EntityCategory.CONFIG
 
-    def turn_on(self, **kwargs: Any) -> None:
-        """Turn the sounds on."""
+    async def async_update(self) -> None:
+        """Re-sync the clock once a day while enabled."""
+        if not self.device.sync_time:
+            return
+        now = time.monotonic()
+        if now - self.device.last_time_sync < 24 * 3600:
+            return
+        self.device.last_time_sync = now
         self.hass.async_create_task(
             self.device.set_time(datetime.datetime.now())
         )
-        self._attr_is_on = True
 
-    def turn_off(self, **kwargs: Any) -> None:
-        """Turn the sounds off."""
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Enable time sync and set the clock right away."""
+        self.device.sync_time = True
+        self.device.last_time_sync = time.monotonic()
+        self.hass.async_create_task(
+            self.device.set_time(datetime.datetime.now())
+        )
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Disable time synchronization."""
         self.device.sync_time = False
-        self._attr_is_on = False

--- a/tests/test_time_sync_switch.py
+++ b/tests/test_time_sync_switch.py
@@ -1,0 +1,138 @@
+"""Regressions for the time sync switch."""
+
+import asyncio
+import os
+import sys
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "custom_components",
+        )
+    )
+)
+
+from delonghi_primadonna.device import DelongiPrimadonna  # noqa: E402
+from delonghi_primadonna.switch import \
+    DelongiPrimadonnaTimeSyncSwitch  # noqa: E402
+
+CONFIG = {
+    "mac": "00:11:22:33:44:55",
+    "model": "TEST",
+    "name": "TEST",
+}
+
+
+class FakeHass:
+    """Records tasks instead of running them."""
+
+    def __init__(self):
+        self.tasks = []
+
+    def async_create_task(self, coro):
+        self.tasks.append(coro)
+        coro.close()
+        return None
+
+
+def make_switch():
+    device = DelongiPrimadonna(CONFIG, None)
+    hass = FakeHass()
+    switch = DelongiPrimadonnaTimeSyncSwitch(device, hass)
+    switch.hass = hass
+    return switch, device, hass
+
+
+async def test_turn_on_enables_synchronisation():
+    """Turning the switch on must actually enable syncing.
+
+    It only ever set the clock once and left sync_time False, so the
+    switch could turn synchronisation off but never on.
+    """
+    switch, device, _ = make_switch()
+
+    assert device.sync_time is False
+    await switch.async_turn_on()
+
+    assert device.sync_time is True
+    assert switch.is_on is True
+
+
+async def test_turn_off_disables_synchronisation():
+    switch, device, _ = make_switch()
+    await switch.async_turn_on()
+
+    await switch.async_turn_off()
+
+    assert device.sync_time is False
+    assert switch.is_on is False
+
+
+async def test_state_follows_the_device():
+    """is_on reads the device rather than a private copy."""
+    switch, device, _ = make_switch()
+
+    device.sync_time = True
+    assert switch.is_on is True
+    device.sync_time = False
+    assert switch.is_on is False
+
+
+async def test_turn_on_sets_the_clock_once():
+    switch, _, hass = make_switch()
+
+    await switch.async_turn_on()
+
+    assert len(hass.tasks) == 1
+
+
+async def test_daily_resync_waits_a_day():
+    switch, device, hass = make_switch()
+    await switch.async_turn_on()
+    hass.tasks.clear()
+
+    await switch.async_update()
+    assert hass.tasks == [], "re-synced again immediately after turning on"
+
+    device.last_time_sync -= 25 * 3600
+    await switch.async_update()
+    assert len(hass.tasks) == 1, "did not re-sync after a day"
+
+
+async def test_no_resync_while_disabled():
+    switch, device, hass = make_switch()
+    device.sync_time = False
+    device.last_time_sync -= 25 * 3600
+
+    await switch.async_update()
+
+    assert hass.tasks == []
+
+
+async def test_switch_methods_are_coroutines():
+    """HA runs sync turn_on in an executor thread, where calling
+    hass.async_create_task is not thread safe."""
+    switch, _, _ = make_switch()
+
+    assert asyncio.iscoroutinefunction(switch.async_turn_on)
+    assert asyncio.iscoroutinefunction(switch.async_turn_off)
+    own = type(switch).__dict__
+    assert "turn_on" not in own, "still defines a synchronous turn_on"
+    assert "turn_off" not in own, "still defines a synchronous turn_off"
+
+
+async def run_tests():
+    await test_turn_on_enables_synchronisation()
+    await test_turn_off_disables_synchronisation()
+    await test_state_follows_the_device()
+    await test_turn_on_sets_the_clock_once()
+    await test_daily_resync_waits_a_day()
+    await test_no_resync_while_disabled()
+    await test_switch_methods_are_coroutines()
+    print("[SUCCESS] Time sync switch verified.")
+
+
+if __name__ == "__main__":
+    asyncio.run(run_tests())


### PR DESCRIPTION
The **Time sync** switch does not do what its name says.

```python
def turn_on(self, **kwargs: Any) -> None:
    """Turn the sounds on."""
    self.hass.async_create_task(self.device.set_time(datetime.datetime.now()))
    self._attr_is_on = True
```

Three separate problems in those four lines:

**It can only ever turn syncing off.** `turn_on` sets the clock once and leaves `device.sync_time` at `False`; `turn_off` sets it to `False`. And nothing reads the flag anyway — `grep sync_time` finds only the two writes, so the attribute is write-only and the switch state means nothing.

**`turn_on` and `turn_off` are plain methods.** Home Assistant runs those in an executor thread, and `hass.async_create_task` from a worker thread is not thread safe; recent cores warn about exactly this. Both are coroutines now.

**`_attr_is_on` is a private copy** that can drift from the device. `is_on` reads `device.sync_time` instead.

With the flag now meaning something, `async_update` re-syncs the clock once a day while the switch is on. That uses the entity polling the platform already does, since there is no scheduler in the integration to hang it off — say the word if you would rather it lived somewhere else.

The docstrings said "Turn the sounds on/off".

Seven tests, all failing before the change, including one that asserts the class no longer defines a synchronous `turn_on`. They run standalone: `python3 tests/test_time_sync_switch.py`.

3 files, `flake8` and `isort` green on `custom_components`. Rebased on master (1.17.19).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZJvU4uvEcpxdxVSBKyudM

## Summary by Sourcery

Make the time sync switch reliably control and maintain synchronization with the machine clock.

New Features:
- Make the time sync switch enable synchronization and immediately align the machine clock when turned on.
- Add automatic daily clock resynchronization while time synchronization is enabled.

Bug Fixes:
- Ensure the switch state reflects the device synchronization setting instead of a separate entity-local value.
- Use asynchronous switch handlers to safely schedule Home Assistant clock updates.

Tests:
- Add regression coverage for switch behavior, state tracking, coroutine handlers, immediate synchronization, and daily resynchronization.