### PR TITLE
Add a dispensing binary sensor

### DIFF
--- a/custom_components/delonghi_primadonna/binary_sensor.py
+++ b/custom_components/delonghi_primadonna/binary_sensor.py
@@ -26,6 +26,7 @@ async def async_setup_entry(
             DelongiPrimadonnaDescaleSensor(delongh_device, hass),
             DelongiPrimadonnaFilterSensor(delongh_device, hass),
             DelongiPrimadonnaEnabledSensor(delongh_device, hass),
+            DelongiPrimadonnaDispensingSensor(delongh_device, hass),
         ]
     )
     return True
@@ -128,3 +129,23 @@ class DelongiPrimadonnaFilterSensor(
         if self.is_on:
             result = 'mdi:filter-off'
         return result
+
+
+class DelongiPrimadonnaDispensingSensor(
+    DelonghiDeviceEntity, BinarySensorEntity
+):
+    """On while the machine is dispensing a beverage."""
+
+    _attr_device_class = BinarySensorDeviceClass.RUNNING
+    _attr_translation_key = 'dispensing'
+    _attr_icon = 'mdi:coffee-to-go'
+
+    @property
+    def is_on(self) -> bool:
+        """Return True while a beverage is being dispensed."""
+        return self.device.is_dispensing
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        """Expose the dispensing progress percentage."""
+        return {'percentage': self.device.dispensing_percentage}

--- a/custom_components/delonghi_primadonna/device.py
+++ b/custom_components/delonghi_primadonna/device.py
@@ -53,6 +53,7 @@ class MonitorData:
     status: int
     sub_status: int
     nozzle_state: int
+    percentage: int = 0
 
 
 def parse_monitor_data(data: bytes) -> MonitorData | None:
@@ -68,6 +69,7 @@ def parse_monitor_data(data: bytes) -> MonitorData | None:
     status = 0
     sub_status = 0
     nozzle_state = -1
+    percentage = 0
 
     if answer_id == 0x75:  # MonitorDataV2
         if len(data) < 14:
@@ -92,6 +94,10 @@ def parse_monitor_data(data: bytes) -> MonitorData | None:
 
         # Nozzle State: Byte 4 (from MonitorDataV2.a())
         nozzle_state = data[4]
+
+        # Dispensing progress: byte 11 carries the percentage
+        # (see longshot MonitorV2Response)
+        percentage = data[11]
 
     elif answer_id == 0x70:  # MonitorData (v1)
         if len(data) < 11:
@@ -123,7 +129,9 @@ def parse_monitor_data(data: bytes) -> MonitorData | None:
     else:
         return None
 
-    return MonitorData(switches, alarms, status, sub_status, nozzle_state)
+    return MonitorData(
+        switches, alarms, status, sub_status, nozzle_state, percentage
+    )
 
 
 class BeverageEntityFeature(IntFlag):
@@ -292,6 +300,8 @@ class DelongiPrimadonna:
         self.switches = DeviceSwitches()
         self.active_switches: list[MachineSwitch] = []
         self.sync_time = False
+        self.is_dispensing = False
+        self.dispensing_percentage = 0
         self._lock = asyncio.Lock()
         self._rx_buffer = bytearray()
         self._response_event = None
@@ -570,6 +580,18 @@ class DelongiPrimadonna:
         """Apply parsed monitor data to device state."""
         # Power state
         self.switches.is_on = monitor_data.status > 0
+
+        # Dispensing: milk preparation (10) and hot water (11) are their
+        # own states; 7 covers both idle and dispensing, and the progress
+        # counter is what tells them apart - the same rule longshot uses
+        # for EcamStatus::Busy.
+        self.is_dispensing = (
+            monitor_data.status in (10, 11)
+            or (monitor_data.status == 7 and monitor_data.sub_status != 0)
+        )
+        self.dispensing_percentage = (
+            monitor_data.percentage if self.is_dispensing else 0
+        )
 
         # Nozzle state (only present in v2 / 0x75 packets)
         if monitor_data.nozzle_state != -1:

--- a/custom_components/delonghi_primadonna/strings.json
+++ b/custom_components/delonghi_primadonna/strings.json
@@ -59,6 +59,9 @@
             }
         },
         "binary_sensor": {
+            "dispensing": {
+                "name": "Dispensing"
+            },
             "descaling": {
                 "name": "Descaling"
             },

--- a/custom_components/delonghi_primadonna/translations/de.json
+++ b/custom_components/delonghi_primadonna/translations/de.json
@@ -59,6 +59,9 @@
       }
     },
     "binary_sensor": {
+      "dispensing": {
+          "name": "Bezug läuft"
+      },
       "descaling": {
         "name": "Entkalkung"
       },

--- a/custom_components/delonghi_primadonna/translations/en.json
+++ b/custom_components/delonghi_primadonna/translations/en.json
@@ -59,6 +59,9 @@
       }
     },
     "binary_sensor": {
+      "dispensing": {
+          "name": "Dispensing"
+      },
       "descaling": {
         "name": "Descaling"
       },

--- a/tests/test_dispensing_sensor.py
+++ b/tests/test_dispensing_sensor.py
@@ -1,0 +1,110 @@
+"""Regressions for the dispensing binary sensor."""
+
+import asyncio
+import os
+import sys
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "custom_components",
+        )
+    )
+)
+
+from delonghi_primadonna.binary_sensor import \
+    DelongiPrimadonnaDispensingSensor  # noqa: E402
+from delonghi_primadonna.device import DelongiPrimadonna  # noqa: E402
+from delonghi_primadonna.device import parse_monitor_data  # noqa: E402
+
+CONFIG = {
+    "mac": "00:11:22:33:44:55",
+    "model": "TEST",
+    "name": "TEST",
+}
+
+
+def monitor_v2(status: int, sub_status: int, percentage: int) -> bytes:
+    """Build a 0x75 monitor frame with the fields under test."""
+    data = bytearray(16)
+    data[0] = 0xD0
+    data[1] = 0x12
+    data[2] = 0x75
+    data[8] = 0x00
+    data[9] = status
+    data[10] = sub_status
+    data[11] = percentage
+    return bytes(data)
+
+
+def make_device():
+    return DelongiPrimadonna(CONFIG, None)
+
+
+def apply(device, status, sub_status, percentage):
+    packet = monitor_v2(status, sub_status, percentage)
+    parsed = parse_monitor_data(packet)
+    device._handle_monitor_data(parsed, 0x75, packet)
+    return parsed
+
+
+async def test_percentage_is_parsed_from_byte_11():
+    parsed = parse_monitor_data(monitor_v2(7, 4, 63))
+    assert parsed.percentage == 63
+
+
+async def test_ready_with_progress_counts_as_dispensing():
+    """State 7 is both idle and dispensing; sub_status separates them."""
+    device = make_device()
+
+    apply(device, 7, 4, 63)
+    assert device.is_dispensing is True
+    assert device.dispensing_percentage == 63
+
+    apply(device, 7, 0, 0)
+    assert device.is_dispensing is False
+
+
+async def test_milk_and_hot_water_states_count_as_dispensing():
+    device = make_device()
+
+    apply(device, 10, 0, 20)
+    assert device.is_dispensing is True
+    apply(device, 11, 0, 40)
+    assert device.is_dispensing is True
+
+
+async def test_percentage_is_cleared_when_idle():
+    device = make_device()
+
+    apply(device, 7, 4, 63)
+    apply(device, 7, 0, 63)
+
+    assert device.dispensing_percentage == 0
+
+
+async def test_sensor_reflects_the_device():
+    device = make_device()
+    sensor = DelongiPrimadonnaDispensingSensor(device, None)
+
+    apply(device, 7, 4, 55)
+    assert sensor.is_on is True
+    assert sensor.extra_state_attributes == {'percentage': 55}
+
+    apply(device, 7, 0, 0)
+    assert sensor.is_on is False
+
+
+async def run_tests():
+    await test_percentage_is_parsed_from_byte_11()
+    await test_ready_with_progress_counts_as_dispensing()
+    await test_milk_and_hot_water_states_count_as_dispensing()
+    await test_percentage_is_cleared_when_idle()
+    await test_sensor_reflects_the_device()
+    print("[SUCCESS] Dispensing sensor verified.")
+
+
+if __name__ == "__main__":
+    asyncio.run(run_tests())


### PR DESCRIPTION
Byte 11 of the `0x75` monitor frame carries the dispensing progress as a percentage. `parse_monitor_data` reads bytes 4 to 13 but skips it, so the information is on the wire and thrown away.

This parses it and derives whether a beverage is currently running:

- states **10** and **11** are milk preparation and hot water — dispensing by definition
- state **7** is both idle *and* dispensing, and the sub-status counter is what separates them, the same rule longshot uses for `EcamStatus::Busy`

The sensor is a plain `BinarySensorDeviceClass.RUNNING` on `device.is_dispensing`, with the percentage as a state attribute so it can drive a progress bar without a second entity.

Five tests, covering the byte-11 parse, both dispensing states, the idle-versus-running distinction on state 7, and that the percentage is cleared when idle. `python3 tests/test_dispensing_sensor.py`.

Labels in English and German; other locales fall back.

5 files, 53+/1-. `flake8` and `isort` green on `custom_components`. Rebased on master (1.17.19).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZJvU4uvEcpxdxVSBKyudM

## Summary by Sourcery

Expose beverage dispensing status and progress through a Home Assistant binary sensor.

New Features:
- Add a running binary sensor that indicates when the machine is dispensing and exposes dispensing progress as a percentage attribute.

Bug Fixes:
- Preserve and use the dispensing percentage from monitor frame byte 11 instead of discarding it.

Enhancements:
- Derive dispensing state for milk preparation, hot water, and state 7 using the sub-status to distinguish idle from active dispensing.
- Add English and German labels with locale fallback support.

Tests:
- Add coverage for progress parsing, dispensing-state detection, idle handling, percentage clearing, and sensor state exposure.