### PR TITLE
Name the command in timeout messages

### DIFF
--- a/custom_components/delonghi_primadonna/const.py
+++ b/custom_components/delonghi_primadonna/const.py
@@ -109,6 +109,19 @@ MACHINE_STATUS = {
 """
 Command bytes
 """
+# Command type lives in byte 2. Used to name a command in log messages,
+# so a timeout says what failed instead of only dumping its bytes.
+COMMAND_NAMES = {
+    0x75: 'status poll',
+    0x83: 'beverage',
+    0x84: 'power',
+    0x90: 'write setting',
+    0x95: 'read setting',
+    0xA2: 'statistics',
+    0xA4: 'profile names',
+    0xE2: 'clock',
+}
+
 BYTES_POWER = [0x0d, 0x07, 0x84, 0x0f, 0x02, 0x01, 0x55, 0x12]
 
 # Default bitmask for commands

--- a/custom_components/delonghi_primadonna/const.py
+++ b/custom_components/delonghi_primadonna/const.py
@@ -119,6 +119,7 @@ COMMAND_NAMES = {
     0x95: 'read setting',
     0xA2: 'statistics',
     0xA4: 'profile names',
+    0xA9: 'profile selection',
     0xE2: 'clock',
 }
 

--- a/custom_components/delonghi_primadonna/device.py
+++ b/custom_components/delonghi_primadonna/device.py
@@ -29,14 +29,15 @@ from .const import (AMERICANO_OFF, AMERICANO_ON, AVAILABLE_PROFILES,
                     BYTES_WATER_TEMPERATURE_COMMAND, COFFE_OFF, COFFE_ON,
                     COFFEE_GROUNDS_CONTAINER_CLEAN,
                     COFFEE_GROUNDS_CONTAINER_DETACHED,
-                    COFFEE_GROUNDS_CONTAINER_FULL, CONTROLL_CHARACTERISTIC,
-                    DEBUG, DEFAULT_DEVICE_NAME, DEFAULT_IMAGE_URL,
-                    DEVICE_READY, DEVICE_STATUS, DEVICE_TURNOFF, DOMAIN,
-                    DOPPIO_OFF, DOPPIO_ON, ESPRESSO2_OFF, ESPRESSO2_ON,
-                    ESPRESSO_OFF, ESPRESSO_ON, HOTWATER_OFF, HOTWATER_ON,
-                    LONG_OFF, LONG_ON, MACHINE_STATUS, NAME_CHARACTERISTIC,
-                    NOZZLE_STATE, START_COFFEE, STEAM_OFF, STEAM_ON,
-                    WATER_SHORTAGE, WATER_TANK_DETACHED)
+                    COFFEE_GROUNDS_CONTAINER_FULL, COMMAND_NAMES,
+                    CONTROLL_CHARACTERISTIC, DEBUG, DEFAULT_DEVICE_NAME,
+                    DEFAULT_IMAGE_URL, DEVICE_READY, DEVICE_STATUS,
+                    DEVICE_TURNOFF, DOMAIN, DOPPIO_OFF, DOPPIO_ON,
+                    ESPRESSO2_OFF, ESPRESSO2_ON, ESPRESSO_OFF, ESPRESSO_ON,
+                    HOTWATER_OFF, HOTWATER_ON, LONG_OFF, LONG_ON,
+                    MACHINE_STATUS, NAME_CHARACTERISTIC, NOZZLE_STATE,
+                    START_COFFEE, STEAM_OFF, STEAM_ON, WATER_SHORTAGE,
+                    WATER_TANK_DETACHED)
 from .machine_switch import MachineSwitch, parse_switches
 from .model import get_machine_model
 
@@ -53,6 +54,13 @@ class MonitorData:
     status: int
     sub_status: int
     nozzle_state: int
+
+
+def describe_command(message) -> str:
+    """Name a command for log messages, falling back to its type byte."""
+    if len(message) < 3:
+        return 'unknown'
+    return COMMAND_NAMES.get(message[2], f'0x{message[2]:02x}')
 
 
 def parse_monitor_data(data: bytes) -> MonitorData | None:
@@ -810,7 +818,9 @@ class DelongiPrimadonna:
                         )
                     except asyncio.TimeoutError:
                         _LOGGER.warning(
-                            'Timeout waiting for response to command: %s',
+                            'Timeout waiting for a reply to the %s '
+                            'command: %s',
+                            describe_command(message_to_send),
                             hexlify(bytearray(message_to_send), " ")
                         )
                     finally:

--- a/tests/test_command_names.py
+++ b/tests/test_command_names.py
@@ -1,0 +1,44 @@
+"""A timeout should say which command failed."""
+
+import asyncio
+import os
+import sys
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "custom_components",
+        )
+    )
+)
+
+from delonghi_primadonna.const import BYTES_POWER  # noqa: E402
+from delonghi_primadonna.device import describe_command  # noqa: E402
+
+
+async def test_known_commands_are_named():
+    assert describe_command(BYTES_POWER) == "power"
+    assert describe_command([0x0D, 0x07, 0xA4]) == "profile names"
+    assert describe_command([0x0D, 0x07, 0x95]) == "read setting"
+
+
+async def test_unknown_command_falls_back_to_its_type_byte():
+    assert describe_command([0x0D, 0x07, 0x5A]) == "0x5a"
+
+
+async def test_short_message_does_not_raise():
+    assert describe_command([0x0D]) == "unknown"
+    assert describe_command([]) == "unknown"
+
+
+async def run_tests():
+    await test_known_commands_are_named()
+    await test_unknown_command_falls_back_to_its_type_byte()
+    await test_short_message_does_not_raise()
+    print("[SUCCESS] Command naming verified.")
+
+
+if __name__ == "__main__":
+    asyncio.run(run_tests())

--- a/tests/test_command_names.py
+++ b/tests/test_command_names.py
@@ -22,6 +22,36 @@ async def test_known_commands_are_named():
     assert describe_command(BYTES_POWER) == "power"
     assert describe_command([0x0D, 0x07, 0xA4]) == "profile names"
     assert describe_command([0x0D, 0x07, 0x95]) == "read setting"
+    assert describe_command([0x0D, 0x06, 0xA9]) == "profile selection"
+
+
+async def test_every_command_the_code_sends_has_a_name():
+    """A command type that is sent but unnamed defeats the purpose."""
+    import re
+
+    root = os.path.join(
+        os.path.dirname(__file__), "..", "custom_components",
+        "delonghi_primadonna",
+    )
+    with open(os.path.join(root, "const.py"), encoding="utf-8") as handle:
+        const = handle.read()
+    with open(os.path.join(root, "device.py"), encoding="utf-8") as handle:
+        device = handle.read()
+
+    sent = set()
+    for match in re.finditer(r"^BYTES_[A-Z0-9_]+ = \[([^\]]+)\]", const, re.M):
+        parts = [p.strip() for p in match.group(1).split(",")]
+        if len(parts) > 2:
+            sent.add(int(parts[2], 16))
+    for byte in re.findall(
+        r"\[0x0[dD],\s*0x[0-9a-fA-F]{2},\s*0x([0-9a-fA-F]{2})", device
+    ):
+        sent.add(int(byte, 16))
+
+    unnamed = sorted(
+        hex(op) for op in sent if describe_command([0, 0, op]).startswith("0x")
+    )
+    assert not unnamed, f"sent but unnamed: {unnamed}"
 
 
 async def test_unknown_command_falls_back_to_its_type_byte():
@@ -35,6 +65,7 @@ async def test_short_message_does_not_raise():
 
 async def run_tests():
     await test_known_commands_are_named()
+    await test_every_command_the_code_sends_has_a_name()
     await test_unknown_command_falls_back_to_its_type_byte()
     await test_short_message_does_not_raise()
     print("[SUCCESS] Command naming verified.")


### PR DESCRIPTION
A timeout currently logs only the raw bytes:

```
Timeout waiting for response to command: 0d 07 a4 f0 01 06 00 00
```

which tells you something failed but not what. Byte 2 already identifies the command type, so this maps it to a name:

```
Timeout waiting for a reply to the profile names command: 0d 07 a4 f0 01 06 00 00
```

The bytes stay for the detail. `describe_command` falls back to `0x5a` for a type the table does not know, and returns `unknown` for a message too short to have a type byte, so it cannot itself raise inside a warning path.

Three tests. `python3 tests/test_command_names.py`.

3 files, `flake8` and `isort` green. Rebased on master (1.17.19).

Pairs naturally with #255 — that one stops waiting for replies that never come, this one makes the remaining timeouts legible — but the two are independent and can go in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZJvU4uvEcpxdxVSBKyudM

## Summary by Sourcery

Improve timeout diagnostics by naming the command associated with each failed reply.

Bug Fixes:
- Make timeout warnings identify the command by name while retaining the raw command bytes for troubleshooting.

Enhancements:
- Add safe command description fallbacks for unknown command types and short messages.
- Centralize names for all supported command types.

Tests:
- Add coverage for known command names, unnamed sent commands, unknown command types, and short-message handling.