### PR TITLE
Import ScannerEntity from its supported location

### DIFF
--- a/custom_components/delonghi_primadonna/device_tracker.py
+++ b/custom_components/delonghi_primadonna/device_tracker.py
@@ -2,7 +2,7 @@
 
 import asyncio
 
-from homeassistant.components.device_tracker.config_entry import ScannerEntity
+from homeassistant.components.device_tracker import ScannerEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback


### PR DESCRIPTION
## What

`ScannerEntity` is imported from `homeassistant.components.device_tracker.config_entry`, which is a deprecated alias. The component package re-exports the class, and that is the supported path.

```python
-from homeassistant.components.device_tracker.config_entry import ScannerEntity
+from homeassistant.components.device_tracker import ScannerEntity
```

## Why now

Home Assistant marks the alias for removal in **2027.6** — from `homeassistant/components/device_tracker/config_entry.py` on `dev`:

```python
_ScannerEntity, "homeassistant.components.device_tracker.ScannerEntity", "2027.6"
```

and `homeassistant/components/device_tracker/__init__.py` re-exports it, so the new path works on every version this integration supports:

```python
from .config_entry import (
    BaseScannerEntity,
    ScannerEntity,
    ScannerEntityDescription,
```

Until it is changed, HA logs a deprecation warning naming this integration on every start, and the import breaks outright in 2027.6.

## Scope

One line in `device_tracker.py`. No behaviour change — same class, supported path. `flake8 custom_components` and `isort --check-only custom_components` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Update the device tracker integration to import Home Assistant's ScannerEntity from its supported package path, avoiding deprecation warnings and future import failures.