### PR TITLE
Document the 0xa4 profile-list exchange

### DIFF
--- a/DEBUG_NOTES.md
+++ b/DEBUG_NOTES.md
@@ -81,7 +81,7 @@ The request id is the third byte of the command, the response id must be the sam
 | 0x95     |                                                     |
 | 0xa2     | Statistics request/response                         |
 | 0xa3     |                                                     |
-| 0xa4     | Request profile list                                |
+| 0xa4     | Request profile list (answered only while awake)    |
 | 0xa5     |                                                     |
 | 0xa9     | Switch the user profile                             |
 | 0xaa     |                                                     |
@@ -172,3 +172,59 @@ This command is used to request various counters (beverages, maintenance, etc.) 
 > [!NOTE]
 > **The Milk Cleaning ID Discrepancy**
 > Analysis of the decompiled APK (`b7.e.java` line 508) shows that the official app requests **ID 115** for the milk cleaning counter. However, some integration users have reported that their machines provide this value on **ID 111**. The current implementation uses 111, but 115 is worth investigating if 111 returns 0.
+
+### Profile list (0xa4)
+
+Captured 2026-08-20 on a machine with six profiles.
+
+**Only answered while the machine is awake.** In standby it stays silent -
+not even a status frame comes back - so the request times out. Statistics
+(`0xa2`) and settings (`0x95`) *are* answered in standby, which is what
+makes the difference easy to miss.
+
+Request, reading a range of profiles (`<start> <end>`, inclusive):
+
+```
+0d 07 a4 f0 01 03 d8 2e     profiles 1-3
+0d 07 a4 f0 04 06 77 7e     profiles 4-6
+```
+
+Response, ~250 ms later:
+
+```
+d0 44 a4 f0 00 41 00 6e 00 64 00 72 00 65 00 61 00 00 00 00 00 00 00 00 08
+            00 4d 00 61 00 72 00 74 00 69 00 6e 00 00 00 00 00 00 00 00 05
+            00 42 00 45 00 33 00 2f 00 42 00 45 00 4e 00 55 00 54 00 5a 03  ed ed
+```
+
+Layout: 4 byte header, then one 21-byte record per profile, then 2 byte CRC.
+The length byte (`0x44` = 68) is the total frame length minus one.
+
+Each record is 10 characters UTF-16 big-endian, padded with NUL, followed by
+one byte:
+
+| Record | Name | Last byte |
+|---|---|---|
+| 1 | `Andrea` | `0x08` |
+| 2 | `Martin` | `0x05` |
+| 3 | `BE3/BENUTZ` | `0x03` |
+| 4-6 | `BE4/BENUTZ` … | `0x03` |
+
+The last byte is the **icon** shown for that profile. The two personalised
+profiles carry different values while all four factory profiles share one,
+which rules out a simple "configured" flag. Independently confirmed by
+[longshot](https://github.com/mmastrac/longshot), which decodes the same
+structure as `WideStringWithIcon { name: String, icon: u8 }` and uses it for
+both `ProfileNameRead` and `RecipeNameRead`. The icon values themselves are
+not enumerated there.
+
+Names are truncated to the 10 character field: the factory name is
+`BE3/BENUTZER`, the machine reports `BE3/BENUTZ`.
+
+The response carries no index, so the reader has to remember which range it
+asked for.
+
+The two personalised profile names in the example above were replaced with
+placeholders of the same length and the frame's CRC recomputed, so the layout,
+the padding and the icon bytes are exactly as captured while the names are not.
+The factory names are unchanged.


### PR DESCRIPTION
## What

Documents the `0xa4` profile-list exchange in `DEBUG_NOTES.md`: the request form, a full response frame, the record layout, and the trailing icon byte.

## Why it looked unsupported

**`0xa4` is only answered while the machine is awake.** In standby it stays silent — not even a status frame comes back — so the request just times out. Statistics (`0xa2`) and settings (`0x95`) *are* answered in standby, which is what makes the difference easy to miss.

## What the frame says

Request reads an inclusive range:

```
0d 07 a4 f0 01 03 d8 2e     profiles 1-3
0d 07 a4 f0 04 06 77 7e     profiles 4-6
```

The response is a 4-byte header, one 21-byte record per profile, then the CRC. Each record is 10 characters UTF-16 big-endian padded with NUL, followed by one byte — the profile **icon**, not a "configured" flag: the personalised profiles carry different values while all four factory profiles share one.

Cross-checked against [longshot](https://github.com/mmastrac/longshot), which decodes the same structure as `WideStringWithIcon { name: String, icon: u8 }` and uses it for both `ProfileNameRead` and `RecipeNameRead`. The icon values themselves are not enumerated there.

Two further details worth having written down: names are truncated to the 10-character field (the factory name is `BE3/BENUTZER`, the machine reports `BE3/BENUTZ`), and the response carries no index, so the reader has to remember which range it asked for. That last point is the reason behind the range-numbering bug fixed in #250.

## A note on the example frame

The two personalised profile names in the captured response were replaced with placeholders of the same length and the CRC recomputed, so the layout, padding and icon bytes are exactly as captured while the names are not. This is stated in the file itself. Verified after editing: 69 bytes, length byte `0x44` = 68 = frame length minus one, CRC valid under `crc_hqx(init 0x1D0F)`, records decoding cleanly.

## Scope

Documentation only — `DEBUG_NOTES.md`, no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document the 0xa4 profile-list protocol exchange and its operational limitations.

Enhancements:
- Document the 0xa4 profile-list exchange, including its awake-only availability, range requests, response layout, profile icons, name truncation, and range-ordering caveat.

Documentation:
- Expand DEBUG_NOTES.md with captured request and response examples and clarify the profile record format and standby behavior.