### PR TITLE
Separate "machine is off" from "machine will not connect"

### DIFF
--- a/custom_components/delonghi_primadonna/device.py
+++ b/custom_components/delonghi_primadonna/device.py
@@ -46,6 +46,16 @@ from .model import get_machine_model
 
 _LOGGER = logging.getLogger(__name__)
 
+
+class DeviceNotVisible(BleakError):
+    """No connectable adapter currently sees the machine.
+
+    This is what an appliance that is switched off looks like, so it is an
+    expected state rather than a fault. Subclasses BleakError so existing
+    handlers keep working.
+    """
+
+
 START_BYTE = 0xD0
 
 
@@ -466,8 +476,9 @@ class DelongiPrimadonna:
                 self._hass, self.mac, connectable=True
             )
             if not self._device:
-                raise BleakError(
-                    f"A device with address {self.mac} could not be found."
+                raise DeviceNotVisible(
+                    f"{self.mac} is not currently visible to a "
+                    f"connectable Bluetooth adapter"
                 )
 
             _LOGGER.info("Connect to %s", self.mac)
@@ -508,7 +519,10 @@ class DelongiPrimadonna:
 
         except Exception as error:
             self.connected = False
-            _LOGGER.warning(
+            _LOGGER.log(
+                logging.DEBUG
+                if isinstance(error, DeviceNotVisible)
+                else logging.WARNING,
                 "BLE connect error: %s (type: %s)",
                 error,
                 type(error).__name__,
@@ -925,7 +939,12 @@ class DelongiPrimadonna:
                 _LOGGER.warning('BleakDBusError: %s', error)
             except BleakError as error:
                 self.connected = False
-                _LOGGER.warning('BleakError: %s', error)
+                _LOGGER.log(
+                    logging.DEBUG
+                    if isinstance(error, DeviceNotVisible)
+                    else logging.WARNING,
+                    'BleakError: %s', error
+                )
             except asyncio.exceptions.TimeoutError as error:
                 self.connected = False
                 _LOGGER.info('TimeoutError: %s at device connection', error)
@@ -1040,7 +1059,10 @@ class DelongiPrimadonna:
                     return response_received
                 except BleakError as error:
                     self.connected = False
-                    _LOGGER.warning(
+                    _LOGGER.log(
+                        logging.DEBUG
+                        if isinstance(error, DeviceNotVisible)
+                        else logging.WARNING,
                         'BleakError: %s (attempt %d)',
                         error,
                         attempt + 1

--- a/tests/test_ble_lifecycle.py
+++ b/tests/test_ble_lifecycle.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import os
 import sys
 import time
@@ -17,7 +18,8 @@ sys.path.append(
 
 import delonghi_primadonna.device as device_module  # noqa: E402
 from delonghi_primadonna.const import BYTES_STATISTICS_COMMAND  # noqa: E402
-from delonghi_primadonna.device import DelongiPrimadonna  # noqa: E402
+from delonghi_primadonna.device import (DelongiPrimadonna,  # noqa: E402
+                                        DeviceNotVisible)
 from delonghi_primadonna.device_tracker import \
     DelongiPrimadonnaDeviceTracker  # noqa: E402
 
@@ -26,6 +28,15 @@ CONFIG = {
     "model": "TEST",
     "name": "TEST",
 }
+
+
+class _CollectingHandler(logging.Handler):
+    def __init__(self, sink):
+        super().__init__(level=logging.DEBUG)
+        self._sink = sink
+
+    def emit(self, record):
+        self._sink.append(record)
 
 
 def make_device(hass=None):
@@ -565,7 +576,102 @@ async def test_statistics_schedule_respects_throttle():
     assert hass.created_tasks == []
 
 
+async def test_missing_device_raises_device_not_visible():
+    """A machine no adapter can see is an expected state, not a fault."""
+    device = make_device()
+    original_lookup = device_module.bluetooth.async_ble_device_from_address
+    device_module.bluetooth.async_ble_device_from_address = (
+        lambda hass, mac, connectable: None
+    )
+    try:
+        raised = None
+        try:
+            await device._connect()
+        except BleakError as error:
+            raised = error
+    finally:
+        device_module.bluetooth.async_ble_device_from_address = (
+            original_lookup
+        )
+
+    assert isinstance(raised, DeviceNotVisible), (
+        "a machine that is switched off must be distinguishable from a "
+        "machine that refuses to connect"
+    )
+    assert isinstance(raised, BleakError), (
+        "DeviceNotVisible must stay a BleakError so existing handlers "
+        "keep working"
+    )
+
+
+async def test_switched_off_machine_logs_no_warning():
+    """The common case - appliance off - must not spam WARNING."""
+    device = make_device()
+    original_lookup = device_module.bluetooth.async_ble_device_from_address
+    device_module.bluetooth.async_ble_device_from_address = (
+        lambda hass, mac, connectable: None
+    )
+    records = []
+    handler = _CollectingHandler(records)
+    device_module._LOGGER.addHandler(handler)
+    device_module._LOGGER.setLevel(logging.DEBUG)
+    try:
+        try:
+            await device._connect()
+        except BleakError:
+            pass
+    finally:
+        device_module._LOGGER.removeHandler(handler)
+        device_module.bluetooth.async_ble_device_from_address = (
+            original_lookup
+        )
+
+    warnings = [r for r in records if r.levelno >= logging.WARNING]
+    assert not warnings, (
+        "an unreachable machine produced WARNING lines: "
+        f"{[r.getMessage() for r in warnings]}"
+    )
+    assert records, "the event should still be visible at DEBUG"
+
+
+async def test_refusing_machine_still_warns():
+    """A machine in range that will not connect is still a real fault."""
+    device = make_device()
+    original_lookup = device_module.bluetooth.async_ble_device_from_address
+    original_establish = device_module.establish_connection
+    device_module.bluetooth.async_ble_device_from_address = (
+        lambda hass, mac, connectable: object()
+    )
+
+    async def refuse(*args, **kwargs):
+        raise BleakError("device refused the connection")
+
+    device_module.establish_connection = refuse
+    records = []
+    handler = _CollectingHandler(records)
+    device_module._LOGGER.addHandler(handler)
+    device_module._LOGGER.setLevel(logging.DEBUG)
+    try:
+        try:
+            await device._connect()
+        except BleakError:
+            pass
+    finally:
+        device_module._LOGGER.removeHandler(handler)
+        device_module.bluetooth.async_ble_device_from_address = (
+            original_lookup
+        )
+        device_module.establish_connection = original_establish
+
+    warnings = [r for r in records if r.levelno >= logging.WARNING]
+    assert warnings, "a machine that refuses to connect must still warn"
+
+
 async def run_tests():
+    await test_missing_device_raises_device_not_visible()
+    await test_switched_off_machine_logs_no_warning()
+    await test_refusing_machine_still_warns()
+
     await test_connect_success()
     await test_connect_clears_receive_buffer_before_notifications()
     await test_receive_buffer_reassembles_fragmented_packet()

--- a/tests/test_ble_lifecycle.py
+++ b/tests/test_ble_lifecycle.py
@@ -613,6 +613,7 @@ async def test_switched_off_machine_logs_no_warning():
     )
     records = []
     handler = _CollectingHandler(records)
+    previous_level = device_module._LOGGER.level
     device_module._LOGGER.addHandler(handler)
     device_module._LOGGER.setLevel(logging.DEBUG)
     try:
@@ -622,6 +623,7 @@ async def test_switched_off_machine_logs_no_warning():
             pass
     finally:
         device_module._LOGGER.removeHandler(handler)
+        device_module._LOGGER.setLevel(previous_level)
         device_module.bluetooth.async_ble_device_from_address = (
             original_lookup
         )
@@ -649,6 +651,7 @@ async def test_refusing_machine_still_warns():
     device_module.establish_connection = refuse
     records = []
     handler = _CollectingHandler(records)
+    previous_level = device_module._LOGGER.level
     device_module._LOGGER.addHandler(handler)
     device_module._LOGGER.setLevel(logging.DEBUG)
     try:
@@ -658,6 +661,7 @@ async def test_refusing_machine_still_warns():
             pass
     finally:
         device_module._LOGGER.removeHandler(handler)
+        device_module._LOGGER.setLevel(previous_level)
         device_module.bluetooth.async_ble_device_from_address = (
             original_lookup
         )


### PR DESCRIPTION
## The problem

`_connect()` raises when Home Assistant has no connectable route to the MAC:

```python
raise BleakError(f"A device with address {self.mac} could not be found.")
```

For a coffee machine that is switched off most of the day, that is the *normal* state, not a fault. It currently produces WARNING lines — two per attempt, because `_connect()` logs the exception in its `except Exception` block and then re-raises it to a caller that logs it again. On my install the polling loops hit this every few minutes all night.

An unreachable machine and a machine that is in range but refuses to connect are genuinely different events, and only the second one is worth a warning.

## The change

A named condition for the expected case:

```python
class DeviceNotVisible(BleakError):
    """No connectable adapter currently sees the machine."""
```

It subclasses `BleakError`, so every existing `except BleakError` handler keeps working unchanged. The three sites that log a `BleakError` pick the level by type — DEBUG for `DeviceNotVisible`, WARNING for everything else:

```python
_LOGGER.log(
    logging.DEBUG
    if isinstance(error, DeviceNotVisible)
    else logging.WARNING,
    'BleakError: %s', error
)
```

No behaviour change beyond log level, and nothing is silenced that was not already expected.

## Tests

Three added to `tests/test_ble_lifecycle.py`:

- `test_missing_device_raises_device_not_visible` — the type, and that it is still a `BleakError`
- `test_switched_off_machine_logs_no_warning` — no WARNING record, but the event is still visible at DEBUG
- `test_refusing_machine_still_warns` — a machine in range that refuses is as loud as before

Counter-checked rather than assumed: with `DeviceNotVisible` left in place and only the log-level logic reverted, the second test fails with

```
AssertionError: an unreachable machine produced WARNING lines:
['BLE connect error: … is not currently visible to a connectable Bluetooth adapter (type: DeviceNotVisible)']
```

`flake8 custom_components` and `isort --check-only custom_components` pass.

## Note

While running the suite on this branch I noticed `tests/test_response_correlation.py` also fails on **pristine master**, unrelated to this change: `test_statistics_polling_starts_second_block_at_111` expects the second block at `(111, 10)` and the code requests `(110, 10)`. Happy to open that separately if it is news to you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Classify unavailable machines separately and log expected discovery failures at DEBUG while preserving warnings for connection failures.

Bug Fixes:
- Distinguish an unreachable or switched-off machine from machines that are visible but refuse to connect.
- Prevent expected device-discovery failures from generating WARNING-level log noise while retaining warnings for genuine connection failures.

Enhancements:
- Introduce a dedicated BleakError subtype for devices not currently visible to a connectable Bluetooth adapter.

Tests:
- Add lifecycle tests covering the new error type and DEBUG-versus-WARNING logging behavior for unavailable and refusing machines.